### PR TITLE
MODEXPW-22 Bursar export failed for large patron group

### DIFF
--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/service/impl/BursarExportServiceImpl.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/service/impl/BursarExportServiceImpl.java
@@ -87,7 +87,7 @@ public class BursarExportServiceImpl implements BursarExportService {
       return Collections.emptyList();
     }
 
-    if (users.size() < bucketSize) {
+    if (users.size() <= bucketSize) {
       return fetchAccounts(users, outStandingDays);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,3 +55,5 @@ management.endpoints.web.exposure.include=health
 management.endpoints.web.base-path=/admin
 management.metrics.export.influx.enabled= false
 feign.client.config.default.loggerLevel=basic
+
+bucket.size=${BUCKET_SIZE:50}

--- a/src/test/java/org/folio/dew/batch/bursarfeesfines/service/impl/BursarExportServiceImplTest.java
+++ b/src/test/java/org/folio/dew/batch/bursarfeesfines/service/impl/BursarExportServiceImplTest.java
@@ -1,0 +1,89 @@
+package org.folio.dew.batch.bursarfeesfines.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.folio.dew.client.AccountBulkClient;
+import org.folio.dew.client.AccountClient;
+import org.folio.dew.client.FeefineactionsClient;
+import org.folio.dew.client.ServicePointClient;
+import org.folio.dew.client.TransferClient;
+import org.folio.dew.client.UserClient;
+import org.folio.dew.domain.dto.Account;
+import org.folio.dew.domain.dto.AccountdataCollection;
+import org.folio.dew.domain.dto.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockBeans;
+
+@SpringBootTest(classes = BursarExportServiceImpl.class)
+@MockBeans({
+  @MockBean(UserClient.class),
+  @MockBean(AccountBulkClient.class),
+  @MockBean(FeefineactionsClient.class),
+  @MockBean(TransferClient.class),
+  @MockBean(ServicePointClient.class)
+})
+class BursarExportServiceImplTest {
+  @Autowired
+  private BursarExportServiceImpl bursarExportService;
+  @MockBean
+  private AccountClient client;
+
+  @Test
+  @DisplayName("Find accounts should return empty list for not defined outStanding days")
+  void findAccountsEmptyTest() {
+    final List<User> users = generateUsers(100);
+    final List<Account> accounts = bursarExportService.findAccounts(null, users);
+
+    assertTrue(accounts.isEmpty());
+  }
+
+  @Test
+  @DisplayName("Find accounts should fetch data in several buckets")
+  void findAccountsTest() {
+    when(client.getAccounts(any(), eq(10000L))).thenReturn(mockAccountData());
+
+    final List<User> users = generateUsers(100);
+    final List<Account> accounts = bursarExportService.findAccounts(1L, users);
+
+    assertEquals(2, accounts.size());
+  }
+
+  @Test
+  @DisplayName("Find accounts should fetch data in one call")
+  void findAccountsLessThanBucketSizeTest() {
+    when(client.getAccounts(any(), eq(10000L))).thenReturn(mockAccountData());
+
+    final List<User> users = generateUsers(50);
+    final List<Account> accounts = bursarExportService.findAccounts(1L, users);
+
+    assertEquals(1, accounts.size());
+  }
+
+  private List<User> generateUsers(int size) {
+    return Stream
+      .generate(UUID::randomUUID)
+      .map(UUID::toString)
+      .map(id -> new User().id(id))
+      .limit(size)
+      .collect(Collectors.toList());
+  }
+
+  private AccountdataCollection mockAccountData() {
+    AccountdataCollection accounts = new AccountdataCollection();
+    Account account = new Account().id(UUID.randomUUID().toString());
+    accounts.accounts(List.of(account));
+    return accounts;
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -16,3 +16,5 @@ spring.batch.schema=classpath:db/hsql/schema-hsqldb.sql
 spring.batch.job.enabled=false
 
 folio.tenant.validation.enabled=true
+
+bucket.size=${BUCKET_SIZE:50}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->
https://issues.folio.org/browse/MODEXPW-22
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Split one call to mod-feefines with a lot of request parameters into several.
Add configurable varible `BUCKET_SIZE` (how many params in one request)
