### PR TITLE
embed_postgres no longer an option as of RMB 33

### DIFF
--- a/descriptors/DeploymentDescriptor-template.json
+++ b/descriptors/DeploymentDescriptor-template.json
@@ -2,6 +2,6 @@
   "srvcId": "@artifactId@-@version@",
   "nodeId": "localhost",
   "descriptor": {
-    "exec": "java -Dport=%p -jar ../@artifactId@/target/@artifactId@-fat.jar -Dhttp.port=%p embed_postgres=true"
+    "exec": "java -Dport=%p -jar ../@artifactId@/target/@artifactId@-fat.jar -Dhttp.port=%p"
   }
 }


### PR DESCRIPTION
mod-data-export-worker does not use RMB, so I wonder why that option appeared in the first place.