### PR TITLE
MODEXPW-38 - Saving circulation log with notices "send error" fails

### DIFF
--- a/src/main/resources/swagger.api/schemas/circulationlog/action_type.json
+++ b/src/main/resources/swagger.api/schemas/circulationlog/action_type.json
@@ -39,6 +39,7 @@
       "Renewed through override",
       "Request status changed",
       "Send",
+      "Send error",
       "Staff information only added",
       "Transferred fully",
       "Transferred partially",


### PR DESCRIPTION
[MODEXPW-38](https://issues.folio.org/browse/MODEXPW-38) - Saving circulation log with notices "send error" fails

## Purpose
When saving circulation log with notices marked as "Send error" an error occurs

## Approach
* added missing action value

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
