### PR TITLE
MODEXPW-31 - Bursar transfer form cannot specify days outstanding

### DIFF
--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/service/impl/BursarExportServiceImpl.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/service/impl/BursarExportServiceImpl.java
@@ -43,7 +43,7 @@ public class BursarExportServiceImpl implements BursarExportService {
   private static final String SERVICE_POINT_CODE = "system";
   private static final String DEFAULT_PAYMENT_METHOD = "Bursar";
   private static final String USER_NAME = "System";
-  private static final String ACCOUNT_QUERY = "userId==%s and remaining > 0.0 and metadata.createdDate>=%s";
+  private static final String ACCOUNT_QUERY = "userId==%s and remaining > 0.0 and metadata.createdDate<=%s";
   private static final String USER_QUERY = "(active==\"true\" and patronGroup==%s)";
   private static final String FEEFINE_QUERY = "(accountId==(%s) and (typeAction==(\"Refunded partially\" or \"Refunded fully\")))";
   private static final long DEFAULT_LIMIT = 10000L;


### PR DESCRIPTION
[MODEXPW-31](https://issues.folio.org/browse/MODEXPW-31) - Bursar transfer form cannot specify days outstanding

## Purpose

The original requirement for bursar fees/fines transfers in [UXPROD-2862](https://issues.folio.org/browse/UXPROD-2862) and confirmed in other tickets like [MODBUREXP-1](https://issues.folio.org/browse/MODBUREXP-1) was for the job to pick up any active fees/fines that have been outstanding for more than X (in Cornell's case, 9) days.

What was delivered somehow changed to picking up all fees/fines since the last X days. The difference is important because Cornell only wants to transfer fees/fines that are 9 days old or older to the Bursar. So the only current workaround is to do manual changes to the files, and having to remember to save off new charges to send after they age 9 days, all manually.

## Approach

Changed query to get fee/fines older than specified date

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.