### PR TITLE
MODEXPW-56 - Return the number of records in a file

### DIFF
--- a/src/main/java/org/folio/dew/controller/BulkEditController.java
+++ b/src/main/java/org/folio/dew/controller/BulkEditController.java
@@ -142,12 +142,12 @@ public class BulkEditController implements JobIdApi {
       if (job.getName().contains(ExportType.BULK_EDIT_UPDATE.getValue())) {
         bulkEditRollBackService.putExecutionInfoPerJob(execution.getId(), jobId);
       }
+      return new ResponseEntity<>(Long.toString(countLines(uploadedPath)), HttpStatus.OK);
     } catch (Exception e) {
       String errorMessage = format(FILE_UPLOAD_ERROR, e.getMessage());
       log.error(errorMessage);
       return new ResponseEntity<>(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(HttpStatus.OK);
   }
 
   @Override
@@ -189,5 +189,11 @@ public class BulkEditController implements JobIdApi {
       .collect(joining(" OR "));
   }
   return String.format("barcode==(%s)", barcodes);
+  }
+
+  private long countLines(Path path) throws IOException {
+    try (var lines = Files.lines(path)) {
+      return lines.count();
+    }
   }
 }

--- a/src/test/java/org/folio/dew/controller/UploadControllerTest.java
+++ b/src/test/java/org/folio/dew/controller/UploadControllerTest.java
@@ -122,7 +122,7 @@ class UploadControllerTest extends BaseBatchTest {
   @Test
   @DisplayName("Launch job on upload file with identifiers successfully")
   @SneakyThrows
-  void shouldLaunchJobOnIdentifiersFileUpload() {
+  void shouldLaunchJobAndReturnNumberOfRecordsOnIdentifiersFileUpload() {
     var jobId = UUID.randomUUID();
     service.addBulkEditJobCommand(createBulkEditJobRequest(jobId, ExportType.BULK_EDIT_IDENTIFIERS));
 
@@ -131,10 +131,13 @@ class UploadControllerTest extends BaseBatchTest {
     var bytes = new FileInputStream("src/test/resources/upload/barcodes.csv").readAllBytes();
     var file = new MockMultipartFile("file", "barcodes.csv", MediaType.TEXT_PLAIN_VALUE, bytes);
 
-    mockMvc.perform(multipart(String.format(UPLOAD_URL_TEMPLATE, jobId))
+    var result = mockMvc.perform(multipart(String.format(UPLOAD_URL_TEMPLATE, jobId))
       .file(file)
       .headers(headers))
-      .andExpect(status().isOk());
+      .andExpect(status().isOk())
+      .andReturn();
+
+    assertThat(result.getResponse().getContentAsString(), equalTo("3"));
 
     verify(exportJobManager, times(1)).launchJob(any());
   }


### PR DESCRIPTION
[MODEXPW-56](https://issues.folio.org/browse/MODEXPW-56) - Return the number of records in a file

## Purpose
It is required to send the number of lines in a file from POST request with a file uploading.

## Approach
* Updated controller logic
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
