### PR TITLE
MODEXPW-67 -  FolioExecutionContext is initialized with wrong tenant id if Spring Batch job launches asynchronously in multi tenant cluster

### DIFF
--- a/src/main/java/org/folio/dew/batch/ExportJobManager.java
+++ b/src/main/java/org/folio/dew/batch/ExportJobManager.java
@@ -19,7 +19,7 @@ public class ExportJobManager {
   private final JobExplorer jobExplorer;
 
   @Autowired
-  public ExportJobManager(@Qualifier("asyncJobLauncher") JobLauncher jobLauncher, JobExplorer jobExplorer) {
+  public ExportJobManager(JobLauncher jobLauncher, JobExplorer jobExplorer) {
     jobLaunchingMessageHandler = new JobLaunchingMessageHandler(jobLauncher);
     this.jobExplorer = jobExplorer;
   }

--- a/src/main/java/org/folio/dew/batch/ExportJobManager.java
+++ b/src/main/java/org/folio/dew/batch/ExportJobManager.java
@@ -19,7 +19,7 @@ public class ExportJobManager {
   private final JobExplorer jobExplorer;
 
   @Autowired
-  public ExportJobManager(JobLauncher jobLauncher, JobExplorer jobExplorer) {
+  public ExportJobManager(@Qualifier("asyncJobLauncher") JobLauncher jobLauncher, JobExplorer jobExplorer) {
     jobLaunchingMessageHandler = new JobLaunchingMessageHandler(jobLauncher);
     this.jobExplorer = jobExplorer;
   }

--- a/src/main/java/org/folio/dew/batch/ExportJobManagerCirculationLog.java
+++ b/src/main/java/org/folio/dew/batch/ExportJobManagerCirculationLog.java
@@ -1,0 +1,12 @@
+package org.folio.dew.batch;
+
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExportJobManagerCirculationLog extends ExportJobManager {
+  public ExportJobManagerCirculationLog(JobLauncher jobLauncher, JobExplorer jobExplorer) {
+    super(jobLauncher, jobExplorer);
+  }
+}

--- a/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
+++ b/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
@@ -16,6 +16,7 @@ import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.de.entity.JobCommand;
 import org.folio.dew.batch.ExportJobManager;
+import org.folio.dew.batch.ExportJobManagerCirculationLog;
 import org.folio.dew.batch.bursarfeesfines.service.BursarExportService;
 import org.folio.dew.config.kafka.KafkaService;
 import org.folio.dew.domain.dto.BursarFeeFines;
@@ -42,6 +43,7 @@ import static java.util.Optional.ofNullable;
 import static org.folio.dew.domain.dto.ExportType.BULK_EDIT_IDENTIFIERS;
 import static org.folio.dew.domain.dto.ExportType.BULK_EDIT_QUERY;
 import static org.folio.dew.domain.dto.ExportType.BULK_EDIT_UPDATE;
+import static org.folio.dew.domain.dto.ExportType.CIRCULATION_LOG;
 
 @Service
 @RequiredArgsConstructor
@@ -50,6 +52,7 @@ public class JobCommandsReceiverService {
 
   private final ObjectMapper objectMapper;
   private final ExportJobManager exportJobManager;
+  private final ExportJobManagerCirculationLog exportJobManagerCirculationLog;
   private final BursarExportService bursarExportService;
   private final IAcknowledgementRepository acknowledgementRepository;
   private final MinIOObjectStorageRepository objectStorageRepository;
@@ -111,7 +114,11 @@ public class JobCommandsReceiverService {
           jobCommand.getJobParameters());
 
       acknowledgementRepository.addAcknowledgement(jobCommand.getId().toString(), acknowledgment);
-      exportJobManager.launchJob(jobLaunchRequest);
+      if (jobCommand.getExportType() == CIRCULATION_LOG) {
+        exportJobManagerCirculationLog.launchJob(jobLaunchRequest);
+      } else {
+        exportJobManager.launchJob(jobLaunchRequest);
+      }
     } catch (Exception e) {
       log.error(e.toString(), e);
     }

--- a/src/test/java/org/folio/dew/BaseBatchTest.java
+++ b/src/test/java/org/folio/dew/BaseBatchTest.java
@@ -38,6 +38,7 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -81,9 +82,8 @@ public abstract class BaseBatchTest {
   @Autowired
   protected InMemoryAcknowledgementRepository repository;
   @MockBean
+  @Qualifier("exportJobManager")
   protected ExportJobManager exportJobManager;
-  @MockBean
-  protected ExportJobManagerCirculationLog exportJobManagerCirculationLog;
   @MockBean
   protected Acknowledgment acknowledgment;
 

--- a/src/test/java/org/folio/dew/BaseBatchTest.java
+++ b/src/test/java/org/folio/dew/BaseBatchTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
 import org.folio.dew.batch.ExportJobManager;
+import org.folio.dew.batch.ExportJobManagerCirculationLog;
 import org.folio.dew.repository.InMemoryAcknowledgementRepository;
 import org.folio.dew.repository.MinIOObjectStorageRepository;
 import org.folio.dew.service.JobCommandsReceiverService;
@@ -81,6 +82,8 @@ public abstract class BaseBatchTest {
   protected InMemoryAcknowledgementRepository repository;
   @MockBean
   protected ExportJobManager exportJobManager;
+  @MockBean
+  protected ExportJobManagerCirculationLog exportJobManagerCirculationLog;
   @MockBean
   protected Acknowledgment acknowledgment;
 

--- a/src/test/java/org/folio/dew/BaseBatchTest.java
+++ b/src/test/java/org/folio/dew/BaseBatchTest.java
@@ -82,8 +82,10 @@ public abstract class BaseBatchTest {
   @Autowired
   protected InMemoryAcknowledgementRepository repository;
   @MockBean
+  @Qualifier("exportJobManager")
   protected ExportJobManager exportJobManager;
   @MockBean
+  @Qualifier("exportJobManagerCirculationLog")
   protected ExportJobManagerCirculationLog exportJobManagerCirculationLog;
   @MockBean
   protected Acknowledgment acknowledgment;

--- a/src/test/java/org/folio/dew/BaseBatchTest.java
+++ b/src/test/java/org/folio/dew/BaseBatchTest.java
@@ -82,10 +82,8 @@ public abstract class BaseBatchTest {
   @Autowired
   protected InMemoryAcknowledgementRepository repository;
   @MockBean
-  @Qualifier("exportJobManager")
   protected ExportJobManager exportJobManager;
   @MockBean
-  @Qualifier("exportJobManagerCirculationLog")
   protected ExportJobManagerCirculationLog exportJobManagerCirculationLog;
   @MockBean
   protected Acknowledgment acknowledgment;

--- a/src/test/java/org/folio/dew/BaseBatchTest.java
+++ b/src/test/java/org/folio/dew/BaseBatchTest.java
@@ -85,6 +85,9 @@ public abstract class BaseBatchTest {
   @Qualifier("exportJobManager")
   protected ExportJobManager exportJobManager;
   @MockBean
+  @Qualifier("exportJobManagerCirculationLog")
+  protected ExportJobManagerCirculationLog exportJobManagerCirculationLog;
+  @MockBean
   protected Acknowledgment acknowledgment;
 
   @Value("${spring.application.name}")

--- a/src/test/java/org/folio/dew/service/JobCommandsReceiverServiceTest.java
+++ b/src/test/java/org/folio/dew/service/JobCommandsReceiverServiceTest.java
@@ -33,7 +33,7 @@ class JobCommandsReceiverServiceTest extends BaseBatchTest {
 
     jobCommandsReceiverService.receiveStartJobCommand(jobCommand, acknowledgment);
 
-    verify(exportJobManager, times(1)).launchJob(any());
+    verify(exportJobManagerCirculationLog, times(1)).launchJob(any());
 
     final Acknowledgment savedAcknowledgment = repository.getAcknowledgement(id.toString());
 


### PR DESCRIPTION
[MODEXPW-67](https://issues.folio.org/browse/MODEXPW-67) - FolioExecutionContext is initialized with wrong tenant id if Spring Batch job launches asynchronously in multi tenant cluster

## Purpose
Fix initialization of FolioExecutionContext in multi tenant cluster.

## Approach
Remove async mode when launching Spring Batch jobs where job type is CIRCULATION_LOG.


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
