### PR TITLE
MODEXPW-65 - po edifact mapping fixes

### DIFF
--- a/src/main/java/org/folio/dew/batch/acquisitions/edifact/CompositePOLineConverter.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/edifact/CompositePOLineConverter.java
@@ -2,59 +2,119 @@ package org.folio.dew.batch.acquisitions.edifact;
 
 import io.xlate.edi.stream.EDIStreamException;
 import io.xlate.edi.stream.EDIStreamWriter;
+import liquibase.util.StringUtil;
 import org.folio.dew.batch.acquisitions.edifact.services.MaterialTypeService;
 import org.folio.dew.domain.dto.CompositePoLine;
+import org.folio.dew.domain.dto.Contributor;
+import org.folio.dew.domain.dto.FundDistribution;
+import org.folio.dew.domain.dto.Location;
+import org.folio.dew.domain.dto.ReferenceNumberItem;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.math.BigDecimal;
+
 public class CompositePOLineConverter {
-  private static final String DEFAULT_PUBLISHER = "Default Publisher";
+  private static final int MAX_CHARS_PER_LINE = 70;
   private static final String DEFAULT_PRODUCT_ID = "0993966518";
-  private static final String DEFAULT_CONTRIBUTOR = "Default Contributor";
-  private static final String DEFAULT_PUBLICATION_DATE = "1999";
-  private static final String DEFAULT_MATERIAL_TYPE = "Book";
-  private static final String DEFAULT_PRICE = "49.99";
 
   @Autowired
   private MaterialTypeService materialTypeService;
 
-  public int convertPOLine(CompositePoLine poLine, EDIStreamWriter writer, int currentLineNumber) throws EDIStreamException {
+  public int convertPOLine(CompositePoLine poLine, EDIStreamWriter writer, int currentLineNumber, int quantityOrdered) throws EDIStreamException {
     int messageSegmentCount = 0;
 
+    //TODO This should only be the 13 digit article number. Other identifiers should not be used here
     messageSegmentCount++;
     writeOrderLine(poLine, writer, currentLineNumber);
 
+    //TODO repeat previous field with PIA+5+, repeat the field and use PIA+1+ for everything after the first one
     messageSegmentCount++;
     writeProductID(poLine, writer);
 
-    messageSegmentCount++;
-    writeContributor(poLine, writer);
+    for (Contributor contributor : poLine.getContributors()) {
+      if (contributor.getContributor() != null) {
+        messageSegmentCount++;
+        writeContributor(contributor.getContributor(), writer);
+      }
+    }
+
+    for (String titlePart : getTitleParts(poLine)) {
+      messageSegmentCount++;
+      writeTitle(titlePart, writer);
+    }
+
+    if (poLine.getPublisher() != null) {
+      messageSegmentCount++;
+      writePublisher(poLine.getPublisher(), writer);
+    }
+
+    if (poLine.getPublicationDate() != null) {
+      messageSegmentCount++;
+      writePublicationDate(poLine.getPublicationDate(), writer);
+    }
+
+    String physicalMaterial = getPhysicalMaterial(poLine);
+    if (StringUtil.isNotEmpty(physicalMaterial)) {
+      messageSegmentCount++;
+      writeMaterialType(physicalMaterial, writer);
+    }
+
+    String electronicMaterial = getElectronicMaterial(poLine);
+    if (StringUtil.isNotEmpty(electronicMaterial)) {
+      messageSegmentCount++;
+      writeMaterialType(electronicMaterial, writer);
+    }
 
     messageSegmentCount++;
-    writeTitle(poLine, writer);
+    writeQuantity(quantityOrdered, writer);
+
+    if (poLine.getCost().getPoLineEstimatedPrice() != null) {
+      messageSegmentCount++;
+      writePrice(poLine.getCost().getPoLineEstimatedPrice(), writer);
+    }
 
     messageSegmentCount++;
-    writePublisher(poLine, writer);
+    writePoLineCurrency(poLine, writer);
 
-    messageSegmentCount++;
-    writePublicationDate(poLine, writer);
+    if (poLine.getVendorDetail() != null && StringUtil.isNotEmpty(poLine.getVendorDetail().getInstructions())) {
+      messageSegmentCount++;
+      writeInstructionsToVendor(poLine.getVendorDetail().getInstructions(), writer);
+    }
 
-    messageSegmentCount++;
-    writeMaterialType(poLine, writer);
+    int referenceQuantity = 0;
 
-    messageSegmentCount++;
-    writeQuantity(poLine, writer);
-
-    messageSegmentCount++;
-    writePrice(poLine, writer);
-
+    referenceQuantity++;
     messageSegmentCount++;
     writePOLineNumber(poLine, writer);
 
-    messageSegmentCount++;
-    writeFundCode(poLine, writer);
+    for (FundDistribution fundDistribution : poLine.getFundDistribution()) {
+      if (referenceQuantity >= 10) {
+        //TODO show a warning
+        break;
+      }
+      referenceQuantity++;
+      messageSegmentCount++;
+      writeFundCode(fundDistribution, writer);
+    }
 
-    messageSegmentCount++;
-    writeDeliveryLocation(poLine, writer);
+    if (poLine.getVendorDetail() != null && referenceQuantity < 10) {
+      for (ReferenceNumberItem number : poLine.getVendorDetail().getReferenceNumbers()) {
+        if (referenceQuantity >= 10) {
+          //TODO show a warning
+          break;
+        }
+        if (number.getRefNumber() != null) {
+          referenceQuantity++;
+          messageSegmentCount++;
+          writeVendorReferenceNumber(number.getRefNumber(), writer);
+        }
+      }
+    }
+
+    for (Location location : poLine.getLocations()) {
+      messageSegmentCount++;
+      writeDeliveryLocation(location, writer);
+    }
 
     return messageSegmentCount;
   }
@@ -88,21 +148,11 @@ public class CompositePOLineConverter {
   }
 
   // Author (Contributor)
-  private void writeContributor(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writeContributor(String contributor, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("IMD")
       .writeElement("L")
-      .writeElement("009");
-
-    String contributor = DEFAULT_CONTRIBUTOR;
-    if (poLine.getContributors() != null && !poLine.getContributors()
-      .isEmpty() && poLine.getContributors()
-      .get(0)
-      .getContributor() != null) {
-      contributor = poLine.getContributors()
-        .get(0)
-        .getContributor();
-    }
-    writer.writeStartElement()
+      .writeElement("009")
+      .writeStartElement()
       .writeComponent("")
       .writeComponent("")
       .writeComponent("")
@@ -111,8 +161,7 @@ public class CompositePOLineConverter {
       .writeEndSegment();
   }
 
-  // Title
-  private void writeTitle(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writeTitle(String titlePart, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("IMD")
       .writeElement("L")
       .writeElement("050")
@@ -120,13 +169,12 @@ public class CompositePOLineConverter {
       .writeComponent("")
       .writeComponent("")
       .writeComponent("")
-      .writeComponent(poLine.getTitleOrPackage())
+      .writeComponent(titlePart)
       .endElement()
       .writeEndSegment();
   }
 
-  // Publisher
-  private void writePublisher(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writePublisher(String publisher, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("IMD")
       .writeElement("L")
       .writeElement("109")
@@ -134,13 +182,12 @@ public class CompositePOLineConverter {
       .writeComponent("")
       .writeComponent("")
       .writeComponent("")
-      .writeComponent(poLine.getPublisher() != null ? poLine.getPublisher() : DEFAULT_PUBLISHER)
+      .writeComponent(publisher)
       .endElement()
       .writeEndSegment();
   }
 
-  // Publication date
-  private void writePublicationDate(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writePublicationDate(String publicationDate, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("IMD")
       .writeElement("L")
       .writeElement("170")
@@ -148,27 +195,14 @@ public class CompositePOLineConverter {
       .writeComponent("")
       .writeComponent("")
       .writeComponent("")
-      .writeComponent(poLine.getPublicationDate() != null ? poLine.getPublicationDate() : DEFAULT_PUBLICATION_DATE)
+      .writeComponent(publicationDate)
       .endElement()
       .writeEndSegment();
   }
 
-  // Material type
-  private void writeMaterialType(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
-    writer.writeStartSegment("IMD");
-    String materialTypeId;
-    String material = DEFAULT_MATERIAL_TYPE;
-    if (poLine.getPhysical() != null &&
-      poLine.getPhysical().getMaterialType() != null) {
-      materialTypeId = poLine.getPhysical().getMaterialType();
-      material = materialTypeService.getMaterialTypeName(materialTypeId);
-    } else if (poLine.getEresource() != null &&
-    poLine.getEresource().getMaterialType() != null) {
-      materialTypeId = poLine.getEresource().getMaterialType();
-      material = materialTypeService.getMaterialTypeName(materialTypeId);
-    }
-
-    writer.writeElement("L")
+  private void writeMaterialType(String material, EDIStreamWriter writer) throws EDIStreamException {
+    writer.writeStartSegment("IMD")
+      .writeElement("L")
       .writeElement("180")
       .writeStartElement()
       .writeComponent("")
@@ -180,33 +214,51 @@ public class CompositePOLineConverter {
   }
 
   // Quantity ordered
-  private void writeQuantity(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writeQuantity(int quantityOrdered, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("QTY")
       .writeStartElement()
       .writeComponent("21")
-      .writeComponent(String.valueOf(getQuantity(poLine))) // quantity value (always 1?)
+      .writeComponent(String.valueOf(quantityOrdered))
       .endElement()
       .writeEndSegment();
   }
 
-  // Price - Several different kinds of qualifiers may be used; see documentation
-  private void writePrice(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
-    writer.writeStartSegment("PRI");
-
-    String price = DEFAULT_PRICE;
-    if (poLine.getCost() != null && poLine.getCost()
-      .getPoLineEstimatedPrice() != null) {
-      price = String.valueOf(poLine.getCost()
-        .getPoLineEstimatedPrice());
-    }
-    writer.writeStartElement()
-      .writeComponent("AAB")
-      .writeComponent(price)
+  private void writePrice(BigDecimal price, EDIStreamWriter writer) throws EDIStreamException {
+    writer.writeStartSegment("PRI")
+      .writeStartElement()
+      .writeComponent("AAF")
+      .writeComponent(String.valueOf(price))
       .endElement()
       .writeEndSegment();
   }
 
-  // FOLIO POL
+  private void writePoLineCurrency(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+    writer.writeStartSegment("CUX")
+      .writeStartElement()
+      .writeComponent("2")
+      .writeComponent(poLine.getCost().getCurrency())
+      .writeComponent("9")
+      .endElement()
+      .writeEndSegment();
+  }
+
+  private void writeInstructionsToVendor(String instructions, EDIStreamWriter writer) throws EDIStreamException {
+    writer.writeStartSegment("FTX")
+      .writeElement("LIN")
+      .writeElement("")
+      .writeStartElement()
+      .writeComponent("")
+      .writeComponent("")
+      .writeComponent(instructions)
+      .endElement()
+      .writeEndSegment();
+  }
+
+  private String[] getTitleParts(CompositePoLine poLine) {
+    String title = poLine.getTitleOrPackage();
+    return title.split("(?<=\\G.{" + MAX_CHARS_PER_LINE + "})");
+  }
+
   private void writePOLineNumber(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("RFF")
       .writeStartElement()
@@ -216,24 +268,35 @@ public class CompositePOLineConverter {
       .writeEndSegment();
   }
 
-  // FOLIO fund code (Also expense class?)
-  private void writeFundCode(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  // FOLIO fund code and expense class
+  private void writeFundCode(FundDistribution fundDistribution, EDIStreamWriter writer) throws EDIStreamException {
+    //TODO Make a call to get expense class by ID fundDistribution.getExpenseClassId()
+    //String fundCodeWithExpenseClass = fundDistribution.getCode() + "?:" + expenseClass;
     writer.writeStartSegment("RFF")
       .writeStartElement()
       .writeComponent("BFN")
-      .writeComponent("LIBRARY")
+      .writeComponent(fundDistribution.getCode())//fundCodeWithExpenseClass
       .endElement()
       .writeEndSegment();
   }
 
-  // Delivery location
-  private void writeDeliveryLocation(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writeVendorReferenceNumber(String number, EDIStreamWriter writer) throws EDIStreamException {
+    writer.writeStartSegment("RFF")
+      .writeStartElement()
+      .writeComponent("SLI")
+      .writeComponent(number)
+      .endElement()
+      .writeEndSegment();
+  }
+
+  private void writeDeliveryLocation(Location location, EDIStreamWriter writer) throws EDIStreamException {
+    //TODO Make a call to get location code for the ID found here (for holding we still need to get location code, not the holding code)
     writer.writeStartSegment("LOC")
       .writeElement("20")
       .writeStartElement()
       .writeComponent("")
       .writeComponent("")
-      .writeComponent("92")
+      .writeComponent("92")//locationCode
       .endElement()
       .writeEndSegment();
   }
@@ -255,16 +318,19 @@ public class CompositePOLineConverter {
     return productId;
   }
 
-  private int getQuantity(CompositePoLine poLine) {
-    int quantity = 0;
-    if (poLine.getPhysical() != null && poLine.getCost() != null
-      && poLine.getCost().getQuantityPhysical() != null) {
-      quantity += poLine.getCost().getQuantityPhysical();
+  private String getPhysicalMaterial(CompositePoLine poLine) {
+    if (poLine.getPhysical() != null && poLine.getPhysical().getMaterialType() != null) {
+      String materialTypeId = poLine.getPhysical().getMaterialType();
+      return materialTypeService.getMaterialTypeName(materialTypeId);
     }
-    if (poLine.getEresource() != null && poLine.getCost() != null
-      && poLine.getCost().getQuantityElectronic() != null){
-      quantity += poLine.getCost().getQuantityElectronic();
+    return "";
+  }
+
+  private String getElectronicMaterial(CompositePoLine poLine) {
+     if (poLine.getEresource() != null && poLine.getEresource().getMaterialType() != null) {
+      String materialTypeId = poLine.getEresource().getMaterialType();
+      return materialTypeService.getMaterialTypeName(materialTypeId);
     }
-    return quantity;
+    return "";
   }
 }

--- a/src/main/java/org/folio/dew/batch/acquisitions/edifact/CompositePOLineConverter.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/edifact/CompositePOLineConverter.java
@@ -15,6 +15,7 @@ import java.math.BigDecimal;
 
 public class CompositePOLineConverter {
   private static final int MAX_CHARS_PER_LINE = 70;
+  private static final int MAX_NUMBER_OF_REFS = 10;
   private static final String DEFAULT_PRODUCT_ID = "0993966518";
 
   @Autowired
@@ -88,7 +89,7 @@ public class CompositePOLineConverter {
     writePOLineNumber(poLine, writer);
 
     for (FundDistribution fundDistribution : poLine.getFundDistribution()) {
-      if (referenceQuantity >= 10) {
+      if (referenceQuantity >= MAX_NUMBER_OF_REFS) {
         //TODO show a warning
         break;
       }
@@ -97,9 +98,9 @@ public class CompositePOLineConverter {
       writeFundCode(fundDistribution, writer);
     }
 
-    if (poLine.getVendorDetail() != null && referenceQuantity < 10) {
+    if (poLine.getVendorDetail() != null && referenceQuantity < MAX_NUMBER_OF_REFS) {
       for (ReferenceNumberItem number : poLine.getVendorDetail().getReferenceNumbers()) {
-        if (referenceQuantity >= 10) {
+        if (referenceQuantity >= MAX_NUMBER_OF_REFS) {
           //TODO show a warning
           break;
         }

--- a/src/main/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifact.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifact.java
@@ -7,6 +7,8 @@ import org.folio.dew.domain.dto.CompositePurchaseOrder;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class MappingOrdersToEdifact {
@@ -26,10 +28,13 @@ public class MappingOrdersToEdifact {
 
     // Count of messages (one message per purchase order)
     int messageCount = 0;
-
     writer.startInterchange();
     writeStartFile(writer);
-    writeInterchangeHeader(writer);
+
+    String dateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("ddMMyyhhmm"));
+    String dateOfPreparation = dateTime.substring(0, 6);
+    String timeOfPreparation = dateTime.substring(6);
+    writeInterchangeHeader(writer, dateOfPreparation, timeOfPreparation);
 
     // Purchase orders
     for (CompositePurchaseOrder compPO : compPOs) {
@@ -55,7 +60,7 @@ public class MappingOrdersToEdifact {
   }
 
   // Interchange header (Library ID:ID type; Vendor ID:ID type)
-  private void writeInterchangeHeader(EDIStreamWriter writer) throws EDIStreamException {
+  private void writeInterchangeHeader(EDIStreamWriter writer, String dateOfPreparation, String timeOfPreparation) throws EDIStreamException {
     writer.writeStartSegment("UNB")
       .writeStartElement()
       .writeComponent("UNOC")
@@ -65,6 +70,14 @@ public class MappingOrdersToEdifact {
     writer.writeStartElement()
       .writeComponent("901494200")
       .writeComponent("31B")
+      .endElement()
+      .writeStartElement()
+      .writeComponent("12345")
+      .writeComponent("31B")
+      .endElement()
+      .writeStartElement()
+      .writeComponent(dateOfPreparation)
+      .writeComponent(timeOfPreparation)
       .endElement();
 
     writer.writeElement("1001")

--- a/src/main/java/org/folio/dew/batch/acquisitions/edifact/services/MaterialTypeService.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/edifact/services/MaterialTypeService.java
@@ -14,13 +14,13 @@ public class MaterialTypeService {
   private final MaterialTypeClient materialTypeClient;
 
   @Cacheable(cacheNames = "materialTypes")
-  private JSONObject getMaterialType(String id) {
+  public JSONObject getMaterialType(String id) {
     return materialTypeClient.getMaterialType(id);
   }
 
   public String getMaterialTypeName(String id) {
     JSONObject jsonObject = getMaterialType(id);
-    String materialType = "Book";
+    String materialType = "";
 
     if (!jsonObject.isEmpty() && jsonObject.getString("name") != null) {
       materialType = jsonObject.getString("name");

--- a/src/test/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifactTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifactTest.java
@@ -48,7 +48,9 @@ class MappingOrdersToEdifactTest {
     JSONObject secondJson = new JSONObject(getMockData("edifact/acquisitions/comprehensive_composite_purchase_order.json"));
     CompositePurchaseOrder comprehensiveCompPo = mapper.readValue(secondJson.toString(), CompositePurchaseOrder.class);
 
-    //TODO finish minimalistic po json (omitting as many fields as possible) and add it here
+    //TODO remove as many fields as possible from minimalistic po json
+    JSONObject thirdJson = new JSONObject(getMockData("edifact/acquisitions/minimalistic_composite_purchase_order.json"));
+    CompositePurchaseOrder minimalisticCompPo = mapper.readValue(thirdJson.toString(), CompositePurchaseOrder.class);
 
     Mockito.when(materialTypeService.getMaterialTypeName(anyString()))
       .thenReturn("Book");
@@ -56,6 +58,7 @@ class MappingOrdersToEdifactTest {
     List<CompositePurchaseOrder> compPOs = new ArrayList<>();
     compPOs.add(compPo);
     compPOs.add(comprehensiveCompPo);
+    compPOs.add(minimalisticCompPo);
     String ediOrder = mappingOrdersToEdifact.convertOrdersToEdifact(compPOs);
     assertFalse(ediOrder.isEmpty());
     log.info(ediOrder);

--- a/src/test/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifactTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifactTest.java
@@ -3,13 +3,18 @@ package org.folio.dew.batch.acquisitions.edifact;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.IOUtils;
+import org.folio.dew.batch.acquisitions.edifact.services.MaterialTypeService;
 import org.folio.dew.domain.dto.CompositePurchaseOrder;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,21 +27,35 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @Log4j2
 @SpringBootTest
 @AutoConfigureMockMvc
+@RunWith(MockitoJUnitRunner.class)
 class MappingOrdersToEdifactTest {
   @Autowired
   private MappingOrdersToEdifact mappingOrdersToEdifact;
+  @MockBean
+  private MaterialTypeService materialTypeService;
 
   @Test void convertOrdersToEdifact() throws Exception {
-    JSONObject jsonObject = new JSONObject(getMockData("edifact/acquisitions/composite_purchase_order.json"));
     ObjectMapper mapper = new ObjectMapper();
-    CompositePurchaseOrder reqData  = mapper.readValue(jsonObject.toString(), CompositePurchaseOrder.class);
+
+    JSONObject firstJson = new JSONObject(getMockData("edifact/acquisitions/composite_purchase_order.json"));
+    CompositePurchaseOrder compPo = mapper.readValue(firstJson.toString(), CompositePurchaseOrder.class);
+
+    JSONObject secondJson = new JSONObject(getMockData("edifact/acquisitions/comprehensive_composite_purchase_order.json"));
+    CompositePurchaseOrder comprehensiveCompPo = mapper.readValue(secondJson.toString(), CompositePurchaseOrder.class);
+
+    //TODO finish minimalistic po json (omitting as many fields as possible) and add it here
+
+    Mockito.when(materialTypeService.getMaterialTypeName(anyString()))
+      .thenReturn("Book");
 
     List<CompositePurchaseOrder> compPOs = new ArrayList<>();
-    compPOs.add(reqData);
+    compPOs.add(compPo);
+    compPOs.add(comprehensiveCompPo);
     String ediOrder = mappingOrdersToEdifact.convertOrdersToEdifact(compPOs);
     assertFalse(ediOrder.isEmpty());
     log.info(ediOrder);

--- a/src/test/java/org/folio/dew/batch/acquisitions/edifact/MaterialTypeServiceTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/edifact/MaterialTypeServiceTest.java
@@ -15,6 +15,6 @@ class MaterialTypeServiceTest extends BaseBatchTest {
   @Test
   void getMaterialTYpe() {
     String materialType = materialTypeService.getMaterialTypeName("1a54b431-2e4f-452d-9cae-9cee66c9a892");
-    assertEquals(materialType, "Book");
+    assertEquals("", materialType);
   }
 }

--- a/src/test/resources/edifact/acquisitions/comprehensive_composite_purchase_order.json
+++ b/src/test/resources/edifact/acquisitions/comprehensive_composite_purchase_order.json
@@ -64,6 +64,60 @@
           "fundId": "65032151-39a5-4cef-8810-5350eb316300",
           "distributionType": "percentage",
           "value": 100.0
+        },
+        {
+          "code": "USHIST2",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316302",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST3",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316303",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST4",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316304",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST5",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316305",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST6",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316306",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST7",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316307",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST8",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316308",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST9",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316309",
+          "distributionType": "percentage",
+          "value": 100.0
+        },
+        {
+          "code": "USHIST10",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316301",
+          "distributionType": "percentage",
+          "value": 100.0
         }
       ],
       "isPackage": false,

--- a/src/test/resources/edifact/acquisitions/comprehensive_composite_purchase_order.json
+++ b/src/test/resources/edifact/acquisitions/comprehensive_composite_purchase_order.json
@@ -1,0 +1,218 @@
+{
+  "id": "96aec519-e756-4a39-87f2-76a61ea878a1",
+  "approved": false,
+  "billTo": "5f8a321e-6b38-4d90-92d4-bf08f91a2242",
+  "manualPo": false,
+  "notes": [
+    "Check credit card statement to make sure payment shows up"
+  ],
+  "poNumber": "10001",
+  "poNumberPrefix": "pref",
+  "poNumberSuffix": "suff",
+  "orderType": "One-Time",
+  "reEncumber": false,
+  "totalEstimatedPrice": 3.3,
+  "totalEncumbered": 0.0,
+  "totalExpended": 0.0,
+  "totalItems": 4,
+  "vendor": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflowStatus": "Pending",
+  "compositePoLines": [
+    {
+      "id": "81b6503d-1f50-404d-a663-794b7f726ffd",
+      "edition": "",
+      "checkinItems": false,
+      "instanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
+      "acquisitionMethod": "2ee31dec-4dab-4807-938c-b4d35b72f523",
+      "automaticExport": false,
+      "alerts": [],
+      "claims": [],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Moutinho, Luiz",
+          "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+        }
+      ],
+      "cost": {
+        "listUnitPrice": 2.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 1.8
+      },
+      "details": {
+        "productIds": [
+          {
+            "productId": "9783319643991",
+            "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422",
+            "qualifier": ""
+          }
+        ],
+        "subscriptionInterval": 0
+      },
+      "eresource": {
+        "activated": false,
+        "createInventory": "Instance, Holding",
+        "trial": false,
+        "accessProvider": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1"
+      },
+      "fundDistribution": [
+        {
+          "code": "USHIST",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316300",
+          "distributionType": "percentage",
+          "value": 100.0
+        }
+      ],
+      "isPackage": false,
+      "locations": [
+        {
+          "holdingId": "c4a15834-0184-4a6f-9c0c-0ca5bad8286d",
+          "quantity": 1,
+          "quantityPhysical": 1
+        }
+      ],
+      "orderFormat": "Physical Resource",
+      "paymentStatus": "Pending",
+      "physical": {
+        "createInventory": "Instance, Holding, Item",
+        "materialSupplier": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",
+        "volumes": []
+      },
+      "poLineNumber": "10001-1",
+      "publicationDate": "[2017]",
+      "publisher": "Palgrave Macmillan",
+      "purchaseOrderId": "96aec519-e756-4a39-87f2-76a61ea878a1",
+      "receiptStatus": "Pending",
+      "reportingCodes": [],
+      "rush": false,
+      "source": "User",
+      "titleOrPackage": "Futures, biometrics and neuroscience research Luiz Moutinho, Mladen Sokele, editors",
+      "vendorDetail": {
+        "instructions": "",
+        "vendorAccount": "BRXXXXX-01",
+        "referenceNumbers": []
+      },
+      "metadata": {
+        "createdDate": "2021-12-28T08:17:02.171+00:00",
+        "createdByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf",
+        "updatedDate": "2021-12-28T08:17:02.171+00:00",
+        "updatedByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf"
+      }
+    },
+    {
+      "id": "c8d7a6a8-89b9-4711-9e1e-694b3e5ada72",
+      "edition": "",
+      "checkinItems": false,
+      "instanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
+      "acquisitionMethod": "2ee31dec-4dab-4807-938c-b4d35b72f523",
+      "automaticExport": false,
+      "alerts": [],
+      "cancellationRestriction": true,
+      "claims": [],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Sosa, Omar",
+          "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+        },
+        {
+          "contributor": "Keita, Seckou, 1977-",
+          "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+        }
+      ],
+      "cost": {
+        "listUnitPrice": 0.55,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 3,
+        "poLineEstimatedPrice": 1.5
+      },
+      "details": {
+        "productIds": [
+          {
+            "productId": "9783319643991",
+            "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422",
+            "qualifier": ""
+          },
+          {
+            "productId": "OTA-1031 Otá Records",
+            "productIdType": "b5d8cdc4-9441-487c-90cf-0c7ec97728eb"
+          }
+        ],
+        "subscriptionInterval": 0
+      },
+      "fundDistribution": [
+        {
+          "code": "USHIST",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316300",
+          "distributionType": "percentage",
+          "value": 20.0
+        },
+        {
+          "code": "AFRICAHIST",
+          "fundId": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
+          "expenseClassId": "1bcc3247-99bf-4dca-9b0f-7bc51a2998c2",
+          "distributionType": "percentage",
+          "value": 80.0
+        }
+      ],
+      "isPackage": false,
+      "locations": [
+        {
+          "locationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "quantity": 1,
+          "quantityPhysical": 1
+        },
+        {
+          "holdingId": "e9285a1c-1dfc-4380-868c-e74073003f43",
+          "quantity": 2,
+          "quantityPhysical": 2
+        }
+      ],
+      "orderFormat": "Physical Resource",
+      "paymentStatus": "Pending",
+      "physical": {
+        "createInventory": "Instance, Holding, Item",
+        "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+        "materialSupplier": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
+        "volumes": []
+      },
+      "poLineNumber": "10001-2",
+      "publisher": "Otá Records, ",
+      "purchaseOrderId": "96aec519-e756-4a39-87f2-76a61ea878a1",
+      "receiptStatus": "Pending",
+      "reportingCodes": [],
+      "rush": true,
+      "source": "User",
+      "titleOrPackage": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      "vendorDetail": {
+        "instructions": "Test vendor instruction text.",
+        "vendorAccount": "BRXXXXX-01",
+        "referenceNumbers": []
+      },
+      "metadata": {
+        "createdDate": "2021-12-28T08:17:02.171+00:00",
+        "createdByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf",
+        "updatedDate": "2021-12-28T08:17:02.171+00:00",
+        "updatedByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf"
+      }
+    }
+  ],
+  "acqUnitIds": [],
+  "tags": {
+    "tagList": [
+      "amazon"
+    ]
+  },
+  "metadata": {
+    "createdDate": "2021-12-28T08:16:56.074+00:00",
+    "createdByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf",
+    "updatedDate": "2021-12-28T08:16:56.074+00:00",
+    "updatedByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf"
+  },
+  "needReEncumber": false
+}

--- a/src/test/resources/edifact/acquisitions/minimalistic_composite_purchase_order.json
+++ b/src/test/resources/edifact/acquisitions/minimalistic_composite_purchase_order.json
@@ -1,0 +1,106 @@
+{
+  "id": "24fa8e44-ae40-4eca-86c3-c4838420ce1f",
+  "approved": false,
+  "notes": [],
+  "poNumber": "10002",
+  "orderType": "One-Time",
+  "reEncumber": false,
+  "totalEstimatedPrice": 1.8,
+  "totalEncumbered": 0.0,
+  "totalExpended": 0.0,
+  "totalItems": 1,
+  "vendor": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "workflowStatus": "Pending",
+  "compositePoLines": [
+    {
+      "id": "31af5b5c-251e-4582-9896-2c9cef360284",
+      "edition": "",
+      "checkinItems": false,
+      "instanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
+      "acquisitionMethod": "2ee31dec-4dab-4807-938c-b4d35b72f523",
+      "automaticExport": false,
+      "alerts": [],
+      "claims": [],
+      "collection": false,
+      "contributors": [
+        {
+          "contributor": "Moutinho, Luiz",
+          "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+        }
+      ],
+      "cost": {
+        "listUnitPrice": 2.0,
+        "currency": "USD",
+        "discount": 10.0,
+        "discountType": "percentage",
+        "quantityPhysical": 1,
+        "poLineEstimatedPrice": 1.8
+      },
+      "details": {
+        "productIds": [
+          {
+            "productId": "9783319643991",
+            "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422",
+            "qualifier": ""
+          }
+        ],
+        "subscriptionInterval": 0
+      },
+      "eresource": {
+        "activated": false,
+        "createInventory": "Instance, Holding",
+        "trial": false,
+        "accessProvider": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1"
+      },
+      "fundDistribution": [
+        {
+          "code": "USHIST",
+          "fundId": "65032151-39a5-4cef-8810-5350eb316300",
+          "distributionType": "percentage",
+          "value": 100.0
+        }
+      ],
+      "isPackage": false,
+      "locations": [
+        {
+          "holdingId": "c4a15834-0184-4a6f-9c0c-0ca5bad8286d",
+          "quantity": 1,
+          "quantityPhysical": 1
+        }
+      ],
+      "orderFormat": "Physical Resource",
+      "paymentStatus": "Pending",
+      "physical": {
+        "createInventory": "Instance, Holding, Item",
+        "materialSupplier": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",
+        "volumes": []
+      },
+      "poLineNumber": "10002-1",
+      "publisher": "Palgrave Macmillan",
+      "purchaseOrderId": "24fa8e44-ae40-4eca-86c3-c4838420ce1f",
+      "receiptStatus": "Pending",
+      "reportingCodes": [],
+      "rush": false,
+      "source": "User",
+      "titleOrPackage": "Futures, biometrics and neuroscience research Luiz Moutinho, Mladen Sokele, editors",
+      "vendorDetail": {
+        "instructions": "",
+        "referenceNumbers": []
+      },
+      "metadata": {
+        "createdDate": "2021-12-28T08:17:02.171+00:00",
+        "createdByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf",
+        "updatedDate": "2021-12-28T08:17:02.171+00:00",
+        "updatedByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf"
+      }
+    }
+  ],
+  "acqUnitIds": [],
+  "metadata": {
+    "createdDate": "2021-12-28T08:16:56.074+00:00",
+    "createdByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf",
+    "updatedDate": "2021-12-28T08:16:56.074+00:00",
+    "updatedByUserId": "7a626480-284e-5b55-9cf2-db32f93956cf"
+  },
+  "needReEncumber": false
+}


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODEXPW-65

## Approach
Fix mapping according to latest requirements.

## TODOs:
1) data ordered can be null however related EDIFACT field is required
2) get vendor edi and type, library edi and type from config
3) create logic to distinguish original orders from resent orders to set related qualifier
4) get system default currency
5) generate file ID
6) show warning if PO line RFF fields were cut off due to reaching the limit of 10
7) improve product ID (lookup product ID type, set related fields and qualifiers based on that type)
8) lookup expense class codes
9) lookup location codes
10) remove as many fields as possible from one of the test PO JSON files to cover all the cases where PO fields are nulls

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
