### PR TITLE
MODEXPW-78 - When file with wrong UUIDs is uploaded we should see errors preview

### DIFF
--- a/src/main/java/org/folio/dew/batch/JobCompletionNotificationListener.java
+++ b/src/main/java/org/folio/dew/batch/JobCompletionNotificationListener.java
@@ -73,7 +73,6 @@ public class JobCompletionNotificationListener extends JobExecutionListenerSuppo
     if (after) {
       if (isBulkEditIdentifiersJob(jobExecution)) {
         handleProcessingErrors(jobExecution, jobId);
-        bulkEditProcessingErrorsService.removeTemporaryErrorStorage(jobId);
       }
       if ((BULK_EDIT_UPDATE.getValue() + "-" + USER.getValue()).equals(jobExecution.getJobInstance().getJobName())) {
         String downloadErrorLink = bulkEditProcessingErrorsService.saveErrorFileAndGetDownloadLink(jobId);

--- a/src/main/java/org/folio/dew/service/BulkEditProcessingErrorsService.java
+++ b/src/main/java/org/folio/dew/service/BulkEditProcessingErrorsService.java
@@ -78,12 +78,14 @@ public class BulkEditProcessingErrorsService {
         var errors = lines.limit(limit)
           .map(message -> new Error().message(message).type(BULK_EDIT_ERROR_TYPE_NAME))
           .collect(toList());
+        log.debug("Errors file {} processing completed", csvFileName);
         return new Errors().errors(errors).totalRecords(errors.size());
       } catch (IOException e) {
         log.error("Failed to read {} errors file for job id {} cause {}", csvFileName, jobId, e);
         throw new BulkEditException(format("Failed to read %s errors file for job id %s", csvFileName, jobId));
       }
     } else {
+      log.debug("Errors file {} doesn't exist - empty error list returned", csvFileName);
       return new Errors().errors(emptyList()).totalRecords(0);
     }
   }

--- a/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
+++ b/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
@@ -58,7 +58,8 @@ public class JobCommandsReceiverService {
   private final ExportJobManagerCirculationLog exportJobManagerCirculationLog;
   private final BursarExportService bursarExportService;
   private final IAcknowledgementRepository acknowledgementRepository;
-  private final MinIOObjectStorageRepository objectStorageRepository;
+  private final MinIOObjectStorageRepository remoteObjectStorageRepository;
+  private final BulkEditProcessingErrorsService bulkEditProcessingErrorsService;
   private final List<Job> jobs;
   private Map<String, Job> jobMap;
   private Map<String, JobCommand> bulkEditJobCommands;
@@ -191,9 +192,10 @@ public class JobCommandsReceiverService {
       }
     }).filter(StringUtils::isNotBlank).distinct().collect(Collectors.toList());
     if (!objects.isEmpty()) {
-      objectStorageRepository.removeObjects(objects);
+      remoteObjectStorageRepository.removeObjects(objects);
     }
     bulkEditJobCommands.remove(jobCommand.getId().toString());
+    bulkEditProcessingErrorsService.removeTemporaryErrorStorage(jobCommand.getId().toString());
     return true;
   }
 


### PR DESCRIPTION
[MODEXPW-78](https://issues.folio.org/browse/MODEXPW-78) - When file with wrong UUIDs is uploaded we should see errors preview

## Purpose
Errors preview is unuvailable.

## Approach
Prevent removing errors.csv file before requesting errors preview. Making removing temporary files by schedule.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
