### PR TITLE
MODEXPW-79 - Errors upon bulk-edit user update

### DIFF
--- a/src/main/java/org/folio/dew/service/BulkEditParseService.java
+++ b/src/main/java/org/folio/dew/service/BulkEditParseService.java
@@ -58,7 +58,7 @@ public class BulkEditParseService {
   private void populateUserFields(User user, UserFormat userFormat) {
     user.setId(userFormat.getId());
     user.setUsername(userFormat.getUserName());
-    user.setExternalSystemId(userFormat.getExternalSystemId());
+    user.setExternalSystemId(StringUtils.isBlank(userFormat.getExternalSystemId()) ? null : userFormat.getExternalSystemId());
     user.setBarcode(userFormat.getBarcode());
     user.setActive(getIsActive(userFormat));
     user.setType(userFormat.getType());

--- a/src/test/java/org/folio/dew/service/BulkEditParseServiceTest.java
+++ b/src/test/java/org/folio/dew/service/BulkEditParseServiceTest.java
@@ -1,0 +1,28 @@
+package org.folio.dew.service;
+
+import org.folio.dew.BaseBatchTest;
+import org.folio.dew.domain.dto.UserFormat;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BulkEditParseServiceTest extends BaseBatchTest {
+  @Autowired
+  private BulkEditParseService bulkEditParseService;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  void userExternalSystemIdShouldNotBeEmptyString(String extSysId) {
+    var userFormat = UserFormat.builder()
+      .externalSystemId(extSysId)
+      .active("true")
+      .departments("")
+      .proxyFor("")
+      .addresses("")
+      .build();
+
+    assertThat(bulkEditParseService.mapUserFormatToUser(userFormat).getExternalSystemId()).isNull();
+  }
+}


### PR DESCRIPTION
[MODEXPW-79](https://issues.folio.org/browse/MODEXPW-79) - Errors upon bulk-edit user update

## Purpose
When trying to update user records, all records cause errors

## Approach
* Fixed user update logic
* Updated tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
