### PR TITLE
MODEXPW-93 - map job name to edi file id

### DIFF
--- a/src/main/java/org/folio/dew/batch/acquisitions/edifact/PurchaseOrdersToEdifactMapper.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/edifact/PurchaseOrdersToEdifactMapper.java
@@ -22,7 +22,7 @@ public class PurchaseOrdersToEdifactMapper {
     this.compositePOConverter = compositePOConverter;
   }
 
-  public String convertOrdersToEdifact(List<CompositePurchaseOrder> compPOs, VendorEdiOrdersExportConfig ediExportConfig, long jobId) throws EDIStreamException {
+  public String convertOrdersToEdifact(List<CompositePurchaseOrder> compPOs, VendorEdiOrdersExportConfig ediExportConfig, String jobName) throws EDIStreamException {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
     EDIOutputFactory factory = EDIOutputFactory.newFactory();
@@ -36,7 +36,7 @@ public class PurchaseOrdersToEdifactMapper {
     writeStartFile(writer);
 
     EdiFileConfig ediFileConfig = new EdiFileConfig();
-    ediFileConfig.setFileId(StringUtils.right(String.valueOf(jobId), 14));
+    ediFileConfig.setFileId(StringUtils.right(jobName, 14));
     ediFileConfig.setLibEdiCode(ediExportConfig.getEdiConfig().getLibEdiCode());
     ediFileConfig.setLibEdiType(ediExportConfig.getEdiConfig().getLibEdiType().getValue().substring(0, 3));
     ediFileConfig.setVendorEdiCode(ediExportConfig.getEdiConfig().getVendorEdiCode());
@@ -57,8 +57,8 @@ public class PurchaseOrdersToEdifactMapper {
     return stream.toString();
   }
 
-  public byte[] convertOrdersToEdifactArray(List<CompositePurchaseOrder> compPOs, VendorEdiOrdersExportConfig ediExportConfig, long jobId) throws EDIStreamException {
-    return convertOrdersToEdifact(compPOs, ediExportConfig, jobId).getBytes(StandardCharsets.UTF_8);
+  public byte[] convertOrdersToEdifactArray(List<CompositePurchaseOrder> compPOs, VendorEdiOrdersExportConfig ediExportConfig, String jobName) throws EDIStreamException {
+    return convertOrdersToEdifact(compPOs, ediExportConfig, jobName).getBytes(StandardCharsets.UTF_8);
   }
 
   // Start of file - Can contain multiple order messages

--- a/src/main/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTasklet.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTasklet.java
@@ -9,6 +9,7 @@ import org.folio.dew.batch.acquisitions.edifact.exceptions.EdifactException;
 import org.folio.dew.batch.acquisitions.edifact.services.OrdersService;
 import org.folio.dew.domain.dto.CompositePoLine;
 import org.folio.dew.domain.dto.CompositePurchaseOrder;
+import org.folio.dew.domain.dto.JobParameterNames;
 import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -43,7 +44,8 @@ public class MapToEdifactTasklet implements Tasklet {
     // save poLineIds in memory
     persistPoLineIds(chunkContext, compOrders);
 
-    String edifactOrderAsString = purchaseOrdersToEdifactMapper.convertOrdersToEdifact(compOrders, ediExportConfig, chunkContext.getStepContext().getJobInstanceId());
+    String jobName = jobParameters.get(JobParameterNames.JOB_NAME).toString();
+    String edifactOrderAsString = purchaseOrdersToEdifactMapper.convertOrdersToEdifact(compOrders, ediExportConfig, jobName);
     // save edifact file content in memory
     ExecutionContextUtils.addToJobExecutionContext(contribution.getStepExecution(), "edifactOrderAsString", edifactOrderAsString, "");
     return RepeatStatus.FINISHED;

--- a/src/main/java/org/folio/dew/domain/dto/JobParameterNames.java
+++ b/src/main/java/org/folio/dew/domain/dto/JobParameterNames.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public class JobParameterNames {
 
   public static final String JOB_ID = "jobId";
+  public static final String JOB_NAME = "jobName";
   public static final String JOB_DESCRIPTION = "jobDescription";
   public static final String TEMP_OUTPUT_FILE_PATH = "tempOutputFilePath";
   public static final String OUTPUT_FILES_IN_STORAGE = "outputFilesInStorage";

--- a/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
+++ b/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
@@ -5,6 +5,7 @@ import static org.folio.dew.domain.dto.ExportType.BULK_EDIT_IDENTIFIERS;
 import static org.folio.dew.domain.dto.ExportType.BULK_EDIT_QUERY;
 import static org.folio.dew.domain.dto.ExportType.BULK_EDIT_UPDATE;
 import static org.folio.dew.domain.dto.ExportType.CIRCULATION_LOG;
+import static org.folio.dew.domain.dto.ExportType.EDIFACT_ORDERS_EXPORT;
 import static org.folio.dew.utils.Constants.MATCHED_RECORDS;
 
 import java.io.File;
@@ -140,9 +141,17 @@ public class JobCommandsReceiverService {
       String.format("%s%s_%tF_%tT_%s", workDir, jobCommand.getExportType(), now, now, jobId);
     paramsBuilder.addString(JobParameterNames.TEMP_OUTPUT_FILE_PATH, outputFileName);
 
+    addOrderExportSpecificParameters(jobCommand, paramsBuilder);
+
     normalizeParametersForBursarExport(paramsBuilder, jobId);
 
     jobCommand.setJobParameters(paramsBuilder.toJobParameters());
+  }
+
+  private void addOrderExportSpecificParameters(JobCommand jobCommand, JobParametersBuilder paramsBuilder) {
+    if (jobCommand.getExportType().equals(EDIFACT_ORDERS_EXPORT)) {
+      paramsBuilder.addString(JobParameterNames.JOB_NAME, jobCommand.getName());
+    }
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifactTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/edifact/MappingOrdersToEdifactTest.java
@@ -64,7 +64,7 @@ class MappingOrdersToEdifactTest {
 
     serviceMocks();
 
-    String ediOrder = purchaseOrdersToEdifactMapper.convertOrdersToEdifact(compPOs, getTestEdiConfig(), 123456789012345L);
+    String ediOrder = purchaseOrdersToEdifactMapper.convertOrdersToEdifact(compPOs, getTestEdiConfig(), "123456789012345");
     assertFalse(ediOrder.isEmpty());
     log.info(ediOrder);
   }
@@ -75,9 +75,9 @@ class MappingOrdersToEdifactTest {
 
     serviceMocks();
 
-    byte[] ediOrder = purchaseOrdersToEdifactMapper.convertOrdersToEdifactArray(compPOs, getTestEdiConfig(), 12345L);
+    byte[] ediOrder = purchaseOrdersToEdifactMapper.convertOrdersToEdifactArray(compPOs, getTestEdiConfig(), "12345");
     assertNotNull(ediOrder);
-    log.info(Arrays.toString(ediOrder));
+    log.info(new String(ediOrder));
   }
 
   private VendorEdiOrdersExportConfig getTestEdiConfig() throws IOException {

--- a/src/test/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTaskletTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTaskletTest.java
@@ -53,7 +53,7 @@ class MapToEdifactTaskletTest extends BaseBatchTest {
 
     doReturn(poCollection).when(ordersService).getCompositePurchaseOrderByQuery(anyString(), anyInt());
     doReturn(comPO).when(ordersService).getCompositePurchaseOrderById(anyString());
-    doReturn("test1").when(purchaseOrdersToEdifactMapper).convertOrdersToEdifact(any(), any(), anyLong());
+    doReturn("test1").when(purchaseOrdersToEdifactMapper).convertOrdersToEdifact(any(), any(), anyString());
 
     JobExecution jobExecution = testLauncher.launchStep("mapToEdifactStep", getJobParameters());
     Collection<StepExecution> actualStepExecutions = jobExecution.getStepExecutions();


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODEXPW-93

## Approach
Add job name to job parameters and then use it to fill EDIFACT File ID field.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
