### PR TITLE
MODEXPW-114 - "Download changed records (CSV)" is missing from Actions Menu

### DIFF
--- a/src/main/java/org/folio/dew/batch/JobCompletionNotificationListener.java
+++ b/src/main/java/org/folio/dew/batch/JobCompletionNotificationListener.java
@@ -213,7 +213,7 @@ public class JobCompletionNotificationListener extends JobExecutionListenerSuppo
   private String saveResult(JobExecution jobExecution) {
     String path = jobExecution.getJobParameters().getString(isBulkEditContentUpdateJob(jobExecution) ? UPDATED_FILE_NAME : TEMP_OUTPUT_FILE_PATH);
     try {
-      if (Files.lines(Path.of(path)).count() == 1) {
+      if (noRecordsFound(path)) {
         return EMPTY;
       }
       var fileNameBulkEditUpdate = path + (isBulkEditContentUpdateJob(jobExecution) ? EMPTY : CSV_EXTENSION);
@@ -225,6 +225,11 @@ public class JobCompletionNotificationListener extends JobExecutionListenerSuppo
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }
+  }
+
+  private boolean noRecordsFound(String path) throws IOException {
+    Path pathToFoundRecords = Path.of(path);
+    return Files.exists(pathToFoundRecords) && Files.lines(pathToFoundRecords).count() == 1;
   }
 
 }


### PR DESCRIPTION
[MODEXPW-114](https://issues.folio.org/browse/MODEXPW-114) - "Download changed records (CSV)" is missing from Actions Menu

## Purpose
Add **Download changed records (CSV)** element to Actions Menu when the bulk edit is done and preview of changed records and errors are populated

## Approach
Add link to the file with changed records to the job with BULK_EDIT_UPDATE type.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
