### PR TITLE
[MODEXPW-95] - (Hotfix) Upgraded spring-boot-starter-parent from 2.5.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         ${project.basedir}/src/main/resources/swagger.api/order-export.yaml
       </order-export.yaml.file>
 
-        <folio-spring-base.version>3.0.1</folio-spring-base.version>
+        <folio-spring-base.version>3.0.2</folio-spring-base.version>
         <folio-spring-tenant.version>1.0.0</folio-spring-tenant.version>
 
         <commons-io.version>2.11.0</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.6</version>
+        <version>2.6.7</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -40,7 +40,7 @@
         ${project.basedir}/src/main/resources/swagger.api/order-export.yaml
       </order-export.yaml.file>
 
-        <folio-spring-base.version>3.0.2</folio-spring-base.version>
+        <folio-spring-base.version>3.0.3</folio-spring-base.version>
         <folio-spring-tenant.version>1.0.0</folio-spring-tenant.version>
 
         <commons-io.version>2.11.0</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
[MODEXPW-95] - Upgraded spring-boot-starter-parent from 2.5.2 to 2.6.6 for LOTUS R1 2022
(https://issues.folio.org/browse/MODEXPW-95)

Purpose
The spring-boot-starter-parent has to be upgraded from 2.5.2 to 2.6.6 to overcome the vulnerability of Spring4Shell in mod-data-export-worker.

Approach
Upgraded spring-boot-starter-parent from 2.5.2 to 2.6.6 in pom.xml