### PR TITLE
MODEXPW-135 - Circulation log export shows another tenant/user's data

### DIFF
--- a/src/main/java/org/folio/dew/batch/circulationlog/CirculationLogCsvItemReader.java
+++ b/src/main/java/org/folio/dew/batch/circulationlog/CirculationLogCsvItemReader.java
@@ -3,17 +3,8 @@ package org.folio.dew.batch.circulationlog;
 import org.folio.dew.batch.CsvItemReader;
 import org.folio.dew.client.AuditClient;
 import org.folio.dew.domain.dto.LogRecord;
-import org.folio.spring.DefaultFolioExecutionContext;
-import org.folio.spring.FolioExecutionContext;
-import static org.folio.spring.integration.XOkapiHeaders.TENANT;
-import org.folio.spring.scope.FolioExecutionScopeExecutionContextManager;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class CirculationLogCsvItemReader extends CsvItemReader<LogRecord> {
 
@@ -21,12 +12,6 @@ public class CirculationLogCsvItemReader extends CsvItemReader<LogRecord> {
 
   private final AuditClient auditClient;
   private final String query;
-
-  @Autowired
-  private FolioExecutionContext folioExecutionContext;
-
-  @Value("#{jobParameters['tenantId']}")
-  private String tenantId;
 
   public CirculationLogCsvItemReader(AuditClient auditClient, String query, Long offset, Long limit) {
     super(offset, limit, QUANTITY_TO_RETRIEVE_PER_HTTP_REQUEST);
@@ -37,10 +22,6 @@ public class CirculationLogCsvItemReader extends CsvItemReader<LogRecord> {
 
   @Override
   protected List<LogRecord> getItems(int offset, int limit) {
-    Map<String, Collection<String>> okapiHeaders = new HashMap<>(folioExecutionContext.getOkapiHeaders());
-    okapiHeaders.put(TENANT, List.of(tenantId));
-    var defaultFolioExecutionContext = new DefaultFolioExecutionContext(folioExecutionContext.getFolioModuleMetadata(), okapiHeaders);
-    FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(defaultFolioExecutionContext);
     return auditClient.getCirculationAuditLogs(query, offset, limit, null).getLogRecords();
   }
 

--- a/src/main/java/org/folio/dew/batch/circulationlog/CirculationLogCsvPartitioner.java
+++ b/src/main/java/org/folio/dew/batch/circulationlog/CirculationLogCsvPartitioner.java
@@ -2,28 +2,11 @@ package org.folio.dew.batch.circulationlog;
 
 import org.folio.dew.batch.CsvPartitioner;
 import org.folio.dew.client.AuditClient;
-import org.folio.spring.DefaultFolioExecutionContext;
-import org.folio.spring.FolioExecutionContext;
-import static org.folio.spring.integration.XOkapiHeaders.TENANT;
-import org.folio.spring.scope.FolioExecutionScopeExecutionContextManager;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class CirculationLogCsvPartitioner extends CsvPartitioner {
 
   private final AuditClient auditClient;
   private final String query;
-
-  @Autowired
-  private FolioExecutionContext folioExecutionContext;
-
-  @Value("#{jobParameters['tenantId']}")
-  private String tenantId;
 
   public CirculationLogCsvPartitioner(Long offset, Long limit, String tempOutputFilePath, AuditClient auditClient, String query) {
     super(offset, limit, tempOutputFilePath);
@@ -34,10 +17,6 @@ public class CirculationLogCsvPartitioner extends CsvPartitioner {
 
   @Override
   protected Long getLimit() {
-    Map<String, Collection<String>> okapiHeaders = new HashMap<>(folioExecutionContext.getOkapiHeaders());
-    okapiHeaders.put(TENANT, List.of(tenantId));
-    var defaultFolioExecutionContext = new DefaultFolioExecutionContext(folioExecutionContext.getFolioModuleMetadata(), okapiHeaders);
-    FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(defaultFolioExecutionContext);
     return Long.valueOf(auditClient.getCirculationAuditLogs(query, 0, 1, null).getTotalRecords());
   }
 

--- a/src/main/java/org/folio/dew/batch/circulationlog/CirculationLogJobConfig.java
+++ b/src/main/java/org/folio/dew/batch/circulationlog/CirculationLogJobConfig.java
@@ -59,7 +59,7 @@ public class CirculationLogJobConfig {
     return stepBuilderFactory
         .get("getCirculationLogChunkStep")
         .partitioner("getCirculationLogPartStep", partitioner)
-        .taskExecutor(taskExecutor)
+//        .taskExecutor(taskExecutor) // At the moment, async mode does not work correctly.
         .step(getCirculationLogPartStep)
         .aggregator(csvFileAssembler)
         .build();

--- a/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
+++ b/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
@@ -35,13 +35,11 @@ import org.folio.dew.domain.dto.JobParameterNames;
 import org.folio.dew.domain.dto.bursarfeesfines.BursarJobPrameterDto;
 import org.folio.dew.repository.IAcknowledgementRepository;
 import org.folio.dew.repository.MinIOObjectStorageRepository;
-import org.folio.spring.FolioExecutionContext;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.integration.launch.JobLaunchRequest;
 import org.springframework.beans.BeanUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
@@ -71,9 +69,6 @@ public class JobCommandsReceiverService {
   @Value("${spring.application.name}")
   private String springApplicationName;
   private String workDir;
-
-  @Autowired
-  private FolioExecutionContext folioExecutionContext;
 
   @PostConstruct
   public void postConstruct() {
@@ -145,7 +140,6 @@ public class JobCommandsReceiverService {
       workDir + LocalDate.now() + MATCHED_RECORDS + "query" :
       String.format("%s%s_%tF_%tT_%s", workDir, jobCommand.getExportType(), now, now, jobId);
     paramsBuilder.addString(JobParameterNames.TEMP_OUTPUT_FILE_PATH, outputFileName);
-    paramsBuilder.addString("tenantId", folioExecutionContext.getTenantId());
 
     addOrderExportSpecificParameters(jobCommand, paramsBuilder);
 

--- a/src/test/java/org/folio/dew/CirculationLogTest.java
+++ b/src/test/java/org/folio/dew/CirculationLogTest.java
@@ -82,7 +82,6 @@ class CirculationLogTest extends BaseBatchTest {
   private JobParameters prepareJobParameters() {
     Map<String, JobParameter> params = new HashMap<>();
     params.put("query", new JobParameter(""));
-    params.put("tenantId", new JobParameter(TENANT));
 
     String jobId = UUID.randomUUID().toString();
     params.put(JobParameterNames.JOB_ID, new JobParameter(jobId));


### PR DESCRIPTION
[MODEXPW-135](https://issues.folio.org/browse/MODEXPW-135) - Circulation log export shows another tenant/user's data

## Purpose
Fix FolioExecutionContext initialization with wrong tenant id in multi tenant cluster.

## Approach
Disable async mode.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
