### PR TITLE
MODEXPW-144 Export eHoldings: use correct tenantId

### DIFF
--- a/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
+++ b/src/main/java/org/folio/dew/service/JobCommandsReceiverService.java
@@ -35,11 +35,13 @@ import org.folio.dew.domain.dto.JobParameterNames;
 import org.folio.dew.domain.dto.bursarfeesfines.BursarJobPrameterDto;
 import org.folio.dew.repository.IAcknowledgementRepository;
 import org.folio.dew.repository.MinIOObjectStorageRepository;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.integration.launch.JobLaunchRequest;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
@@ -69,6 +71,9 @@ public class JobCommandsReceiverService {
   @Value("${spring.application.name}")
   private String springApplicationName;
   private String workDir;
+
+  @Autowired
+  private FolioExecutionContext folioExecutionContext;
 
   @PostConstruct
   public void postConstruct() {
@@ -140,6 +145,7 @@ public class JobCommandsReceiverService {
       workDir + LocalDate.now() + MATCHED_RECORDS + "query" :
       String.format("%s%s_%tF_%tT_%s", workDir, jobCommand.getExportType(), now, now, jobId);
     paramsBuilder.addString(JobParameterNames.TEMP_OUTPUT_FILE_PATH, outputFileName);
+    paramsBuilder.addString("tenantId", folioExecutionContext.getTenantId());
 
     addOrderExportSpecificParameters(jobCommand, paramsBuilder);
 

--- a/src/test/java/org/folio/dew/EHoldingsTest.java
+++ b/src/test/java/org/folio/dew/EHoldingsTest.java
@@ -105,6 +105,7 @@ class EHoldingsTest extends BaseBatchTest {
 
     String jobId = UUID.randomUUID().toString();
     params.put(JobParameterNames.JOB_ID, new JobParameter(jobId));
+    params.put("tenantId", new JobParameter(TENANT));
 
     Date now = new Date();
     String workDir =


### PR DESCRIPTION
https://issues.folio.org/browse/MODEXPW-144
## Purpose
 There is an issue found in mod-data-export-worker. The issue appears when the module executes a task, and this task can potentially use the wrong tenant id, not the right one that came from HTTP request headers and connected to a task. This happens because the tasks are getting executed in a separate thread pool, just using a tenant attached to a concrete thread.
## Approach
Rework the [EHoldingsItemReader.java](https://github.com/folio-org/mod-data-export-worker/blob/master/src/main/java/org/folio/dew/batch/eholdings/EHoldingsItemReader.java) to make it use always correct tenant id. We have to initialize FolioExecutionContext in a reader, take this PR as an example https://github.com/folio-org/mod-data-export-worker/pull/210
