### PR TITLE
MODEXPW-161 Export eHoldings: Exception if title filters are invalid

### DIFF
--- a/src/main/java/org/folio/dew/client/KbEbscoClient.java
+++ b/src/main/java/org/folio/dew/client/KbEbscoClient.java
@@ -37,6 +37,7 @@ public interface KbEbscoClient {
     if (StringUtils.isNotBlank(filters)) {
       Arrays.stream(filters.split("&"))
         .map(param -> param.split("="))
+        .filter(ar -> ar.length == 2)
         .forEach(ar -> params.put(ar[0], ar[1]));
     }
 

--- a/src/test/java/org/folio/dew/EHoldingsTest.java
+++ b/src/test/java/org/folio/dew/EHoldingsTest.java
@@ -11,8 +11,6 @@ import static org.folio.dew.domain.dto.EHoldingsExportConfig.RecordTypeEnum.RESO
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +102,7 @@ class EHoldingsTest extends BaseBatchTest {
     eHoldingsExportConfig.setRecordType(recordType);
     eHoldingsExportConfig.setTitleFields(getClassFields());
     eHoldingsExportConfig.setPackageFields(List.of("packageNotes", "packageAgreements"));
-    eHoldingsExportConfig.setTitleSearchFilters("filter[name]=*");
+    eHoldingsExportConfig.setTitleSearchFilters("filter[name]=*&InvalidFilter");
 
     Map<String, JobParameter> params = new HashMap<>();
     params.put("eHoldingsExportConfig", new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig)));


### PR DESCRIPTION
if there is filter without '=' character than we got OutOfBound exception.
So we will put only filters with size 2, `name` and a `value`
