### PR TITLE
MODEXPW-165 Export of "Package" record (>1k "Titles") with large Note (4k symbols) failed with error

### DIFF
--- a/development.md
+++ b/development.md
@@ -1,0 +1,21 @@
+# Development notes
+## Local testing
+### Vagrant box setup
+It's not possible to fully use mod-data-export-worker with vagrant box for now because there's no AWS configuration for it.
+In order to set it up you need to perform multiple steps:
+- bring up folio Vagrant box.
+- enter Vagrant box with `vagrant ssh`
+- run `docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack -e LOCALSTACK_SERVICES=s3` command to bring up localstack with aws s3 mock
+- run `docker exec -it {localstackContainerId} bash` to enter localstack container
+- run `awslocal s3api create-bucket --bucket sample-bucket` to create bucket
+- then you need to replace `application.minio` properties of `application.yml` configuration file in mod-data-export worker with following (Note: ip address may be changed by should work as is):
+```yaml
+minio:
+    endpoint: ${AWS_URL:http://172.17.0.71:4566}
+    region: ${AWS_REGION:us-east-1}
+    bucket: ${AWS_BUCKET:sample-bucket}
+    accessKey: ${AWS_ACCESS_KEY_ID:test}
+    secretKey: ${AWS_SECRET_ACCESS_KEY:test}
+```
+- to finish, build module and replace it in Vagrant box
+- now you should be able to use export in local Vagrant box

--- a/src/main/java/org/folio/dew/repository/MinIOObjectStorageRepository.java
+++ b/src/main/java/org/folio/dew/repository/MinIOObjectStorageRepository.java
@@ -49,18 +49,20 @@ public class MinIOObjectStorageRepository {
 
   private final MinioClient client;
   private final String bucket;
+  private final String region;
 
   public MinIOObjectStorageRepository(MinIoProperties properties) {
     final String accessKey = properties.getAccessKey();
     final String endpoint = properties.getEndpoint();
-    final String region = properties.getRegion();
+    final String regionProperty = properties.getRegion();
+    final String bucketProperty = properties.getBucket();
     final String secretKey = properties.getSecretKey();
-    log.info("Creating MinIO client endpoint {},region {},bucket {},accessKey {},secretKey {}.", endpoint, region, properties.getBucket(),
+    log.info("Creating MinIO client endpoint {},region {},bucket {},accessKey {},secretKey {}.", endpoint, regionProperty, bucketProperty,
         StringUtils.isNotBlank(accessKey) ? "<set>" : "<not set>", StringUtils.isNotBlank(secretKey) ? "<set>" : "<not set>");
 
     var builder = MinioClient.builder().endpoint(endpoint);
-    if (StringUtils.isNotBlank(region)) {
-      builder.region(region);
+    if (StringUtils.isNotBlank(regionProperty)) {
+      builder.region(regionProperty);
     }
 
     Provider provider;
@@ -74,7 +76,8 @@ public class MinIOObjectStorageRepository {
 
     client = builder.build();
 
-    this.bucket = properties.getBucket();
+    this.bucket = bucketProperty;
+    this.region = regionProperty;
   }
 
   @SneakyThrows
@@ -140,7 +143,7 @@ public class MinIOObjectStorageRepository {
         .method(Method.GET)
         .bucket(response.bucket())
         .object(response.object())
-        .region(response.region())
+        .region(region)
         .versionId(response.versionId())
         .build());
     log.info("Created presigned URL {}.", result);


### PR DESCRIPTION
## Purpose
Fix region for PresignedObjectUrl building

## Approach
- use region from application config for PresignedObjectUrl

## Learning
[MODEXPW-165](https://issues.folio.org/browse/MODEXPW-165)

Issue appears when performing MultipartUpload, because after uploading, 'location' is set into ObjectWriteResponse's 'region' field by MinioClient and this field was used to build PresignedObjectUrl.

## Additional notes
Added development.md with information about local testing.
