### PR TITLE
MODEXPW-175 - eHoldings: export stops after job failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ with further FOLIO Developer documentation at
 
 ### Bulk edit
 In case of no matched records found when uploading CSV file with items or users, link to download matched records is not available for user.
+
+### Environment variables
+| Name                         | Default value          | Description                                                                                                                                                                                           |
+|:-----------------------------|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| KAFKA_HOST                   | localhost              | Kafka broker hostname                                                                                                                                                                                 |
+| KAFKA_PORT                   | 9092                   | Kafka broker port                                                                                                                                                                                     |
+| KAFKA_CONSUMER_POLL_INTERVAL | 3600000                | Max interval before next poll. If long record processing is in place and interval exceeded then consumer will be kicked out of the group and another consumer will start processing the same message. |
+| ENV                          | folio                  | Environment name                                                                                                                                                                                      |
+| AWS_URL                      | http://127.0.0.1:9000/ | AWS url                                                                                                                                                                                               |
+| AWS_REGION                   | -                      | AWS region                                                                                                                                                                                            |
+| AWS_BUCKET                   | -                      | AWS bucket                                                                                                                                                                                            |
+| AWS_ACCESS_KEY_ID            | -                      | AWS access key                                                                                                                                                                                        |
+| AWS_SECRET_ACCESS_KEY        | -                      | AWS secret key                                                                                                                                                                                        |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
     consumer:
       auto-offset-reset: latest
       enable-auto-commit: false
+      properties.max.poll.interval.ms: ${KAFKA_CONSUMER_POLL_INTERVAL:3600000}
   batch:
     job:
       enabled: false


### PR DESCRIPTION
## Purpose
Fix hanging of data export after long job failure.

## Approach
- Increase spring.kafka.consumer.properties.max.poll.interval.ms

#### TODOS and Open Questions
- [x] Are we ok to accept this solution for now?
- [x] Is it reasonable to to implement fire-and-forget later?
- [x] Is approach with pausing a consumer with threading and callbacks would be a good solution? As I understand we are running only one export job at a time (for some reason) so this approach looks like most appropriate for the future.

## Learning
[MODEXPW-175](https://issues.folio.org/browse/MODEXPW-175)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
