### PR TITLE
[MODEXPW-209]. Order line is exported when "Manual" checkbox is enabled in PO

### DIFF
--- a/src/main/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTasklet.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTasklet.java
@@ -90,10 +90,11 @@ public class MapToEdifactTasklet implements Tasklet {
   }
 
   private String buildPurchaseOrderQuery(VendorEdiOrdersExportConfig ediConfig) {
+    var workflowStatusFilter = "workflowStatus==Open";
     var vendorFilter = String.format(" and vendor==%s", ediConfig.getVendorId());
     var automaticExportFilter = " and poLine.automaticExport==true";
-    var lastEDIExportDate = "";//"" and (cql.allRecords=1 NOT poLine.lastEDIExportDate='')";
-    var resultQuery = "(" + "workflowStatus==Open" + vendorFilter + automaticExportFilter + lastEDIExportDate + ")";
+    var notManualFilter = " and cql.allRecords=1 NOT manualPo==true";
+    var resultQuery = "(" + workflowStatusFilter + vendorFilter + automaticExportFilter + notManualFilter + ")";
     log.info("GET purchase orders query: {}", resultQuery);
     return resultQuery;
   }

--- a/src/test/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTaskletTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/edifact/jobs/MapToEdifactTaskletTest.java
@@ -6,8 +6,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 
 import java.io.IOException;
@@ -51,7 +51,8 @@ class MapToEdifactTaskletTest extends BaseBatchTest {
     PurchaseOrderCollection poCollection = objectMapper.readValue(getMockData("edifact/acquisitions/purchase_order_collection.json"), PurchaseOrderCollection.class);
     CompositePurchaseOrder comPO = objectMapper.readValue(getMockData("edifact/acquisitions/composite_purchase_order.json"), CompositePurchaseOrder.class);
 
-    doReturn(poCollection).when(ordersService).getCompositePurchaseOrderByQuery(anyString(), anyInt());
+    String cqlString = "(workflowStatus==Open and vendor==d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1 and poLine.automaticExport==true and cql.allRecords=1 NOT manualPo==true)";
+    doReturn(poCollection).when(ordersService).getCompositePurchaseOrderByQuery(eq(cqlString), eq(Integer.MAX_VALUE));
     doReturn(comPO).when(ordersService).getCompositePurchaseOrderById(anyString());
     doReturn("test1").when(purchaseOrdersToEdifactMapper).convertOrdersToEdifact(any(), any(), anyString());
 
@@ -91,7 +92,8 @@ class MapToEdifactTaskletTest extends BaseBatchTest {
     PurchaseOrderCollection poCollection = objectMapper.readValue(getMockData("edifact/acquisitions/purchase_order_collection.json"), PurchaseOrderCollection.class);
     CompositePurchaseOrder comPO = objectMapper.readValue(getMockData("edifact/acquisitions/composite_purchase_order.json"), CompositePurchaseOrder.class);
     comPO.getCompositePoLines().get(0).getVendorDetail().setVendorAccount(null);
-    doReturn(poCollection).when(ordersService).getCompositePurchaseOrderByQuery(anyString(), anyInt());
+    String cqlString = "(workflowStatus==Open and vendor==d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1 and poLine.automaticExport==true and cql.allRecords=1 NOT manualPo==true)";
+    doReturn(poCollection).when(ordersService).getCompositePurchaseOrderByQuery(eq(cqlString), eq(Integer.MAX_VALUE));
     doReturn(comPO).when(ordersService).getCompositePurchaseOrderById(anyString());
     doReturn("test1").when(purchaseOrdersToEdifactMapper).convertOrdersToEdifact(any(), any(), anyString());
 
@@ -107,7 +109,8 @@ class MapToEdifactTaskletTest extends BaseBatchTest {
   void purchaseOrdersNotFound() throws Exception {
     JobLauncherTestUtils testLauncher = createTestLauncher(edifactExportJob);
     PurchaseOrderCollection poCollection = new PurchaseOrderCollection();
-    doReturn(poCollection).when(ordersService).getCompositePurchaseOrderByQuery(anyString(), anyInt());
+    String cqlString = "(workflowStatus==Open and vendor==d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1 and poLine.automaticExport==true and cql.allRecords=1 NOT manualPo==true)";
+    doReturn(poCollection).when(ordersService).getCompositePurchaseOrderByQuery(eq(cqlString), eq(Integer.MAX_VALUE));
     // when
     JobExecution jobExecution = testLauncher.launchStep("mapToEdifactStep", getJobParameters(false));
 


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODEXPW-209

## Approach
By business requirements orders that have Manual Purches Order checkbox enabled - should not be exported via Edifact export job. In scope of this PR we are adding such filtering by manualPo field.
This field can be as null in database table schema even for open orders, so for this case we don't need to filter such orders.
To achieve this we are using this cql statement:
![image](https://user-images.githubusercontent.com/25097693/183098392-38a69a70-2585-4531-8812-58c6db75be4e.png)
