### PR TITLE
Revert "MODEXPW-185 Implement pausing consumer for Kafka Job Command Listener (#271)"

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     consumer:
       auto-offset-reset: latest
       enable-auto-commit: false
-      properties.max.poll.interval.ms: ${KAFKA_CONSUMER_POLL_INTERVAL:300000}
+      properties.max.poll.interval.ms: ${KAFKA_CONSUMER_POLL_INTERVAL:3600000}
   batch:
     job:
       enabled: false

--- a/src/test/java/org/folio/dew/service/JobCommandsReceiverServiceTest.java
+++ b/src/test/java/org/folio/dew/service/JobCommandsReceiverServiceTest.java
@@ -1,11 +1,9 @@
 package org.folio.dew.service;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
@@ -13,18 +11,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.folio.dew.domain.dto.EHoldingsExportConfig;
+import org.folio.dew.domain.dto.JobParameterNames;
+import org.folio.dew.domain.dto.ExportType;
+import org.folio.de.entity.JobCommand;
+import org.folio.dew.BaseBatchTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.kafka.support.Acknowledgment;
-
-import org.folio.de.entity.JobCommand;
-import org.folio.dew.BaseBatchTest;
-import org.folio.dew.domain.dto.EHoldingsExportConfig;
-import org.folio.dew.domain.dto.ExportType;
-import org.folio.dew.domain.dto.JobParameterNames;
 
 class JobCommandsReceiverServiceTest extends BaseBatchTest {
 
@@ -38,7 +35,7 @@ class JobCommandsReceiverServiceTest extends BaseBatchTest {
 
     jobCommandsReceiverService.receiveStartJobCommand(jobCommand, acknowledgment);
 
-    verify(exportJobManagerSync, timeout(1_000)).launchJob(any());
+    verify(exportJobManagerSync, times(1)).launchJob(any());
 
     final Acknowledgment savedAcknowledgment = repository.getAcknowledgement(id.toString());
 
@@ -55,7 +52,7 @@ class JobCommandsReceiverServiceTest extends BaseBatchTest {
 
     jobCommandsReceiverService.receiveStartJobCommand(jobCommand, acknowledgment);
 
-    verify(exportJobManagerSync, timeout(1_000)).launchJob(any());
+    verify(exportJobManagerSync, times(1)).launchJob(any());
 
     final Acknowledgment savedAcknowledgment = repository.getAcknowledgement(id.toString());
 
@@ -72,27 +69,7 @@ class JobCommandsReceiverServiceTest extends BaseBatchTest {
 
     jobCommandsReceiverService.receiveStartJobCommand(jobCommand, acknowledgment);
 
-    verify(acknowledgment, timeout(1_000)).acknowledge();
-  }
-
-  @Test
-  @DisplayName("Start EHoldings job with pausing/resuming consumer by kafka request")
-  void runJobInNewThreadTest() throws JobExecutionException {
-    doNothing().when(acknowledgment).acknowledge();
-
-    UUID id = UUID.randomUUID();
-    JobCommand jobCommand = createStartEHoldingsJobRequest(id);
-    Thread mainThread = Thread.currentThread();
-
-    doAnswer(invocationOnMock -> {
-      Thread childThread = Thread.currentThread();
-      assertNotEquals(mainThread.getName(), childThread.getName());
-      return null;
-    }).when(exportJobManagerSync).launchJob(any());
-
-    jobCommandsReceiverService.receiveStartJobCommand(jobCommand, acknowledgment);
-
-    verify(exportJobManagerSync, timeout(1_000)).launchJob(any());
+    verify(acknowledgment, times(1)).acknowledge();
   }
 
   private JobCommand createStartCirculationLogJobRequest(UUID id) {


### PR DESCRIPTION
## Purpose
Revert changes brought by PR https://github.com/folio-org/mod-data-export-worker/pull/271/files.

## Approach
Revert commit 16afa096eea6eb15bd842cbcc96f68a4a04844ac.

## Learning
[MODEXPW-185](https://issues.folio.org/browse/MODEXPW-185)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

