### PR TITLE
MODEXPW-189 - users-in-app-update: E-mails bulk-edit updating

### DIFF
--- a/src/main/java/org/folio/dew/service/BulkEditUserContentUpdateService.java
+++ b/src/main/java/org/folio/dew/service/BulkEditUserContentUpdateService.java
@@ -85,6 +85,8 @@ public class BulkEditUserContentUpdateService {
       return new PatronGroupUpdateStrategy();
     case EXPIRATION_DATE:
       return new ExpirationDateUpdateStrategy();
+    case EMAIL_ADDRESS:
+      return new EmailUpdateStrategy();
     default:
       throw new BulkEditException(String.format("Content updates for %s not implemented", update.getOption()));
     }

--- a/src/main/java/org/folio/dew/service/EmailUpdateStrategy.java
+++ b/src/main/java/org/folio/dew/service/EmailUpdateStrategy.java
@@ -1,0 +1,48 @@
+package org.folio.dew.service;
+
+import org.folio.dew.domain.dto.UserContentUpdate;
+import org.folio.dew.domain.dto.UserFormat;
+import org.folio.dew.error.BulkEditException;
+
+public class EmailUpdateStrategy implements UpdateStrategy<UserFormat, UserContentUpdate> {
+  @Override
+  public UserFormat applyUpdate(UserFormat userFormat, UserContentUpdate update, boolean isPreview) {
+    try {
+      var email = new Email(userFormat.getEmail());
+      var findValue = update.getActions().get(0).getValue().toString();
+      var replaceWithValue = update.getActions().get(1).getValue().toString();
+      if (email.domainMatch(findValue)) {
+        return userFormat.withEmail(email.asStringWithDomain(replaceWithValue));
+      }
+      return userFormat;
+    } catch (BulkEditException e) {
+      if (isPreview) {
+        return userFormat;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  static class Email {
+    private final String localPart;
+    private final String domain;
+
+    public Email(String emailString) {
+      var tokens = emailString.split("@");
+      if (tokens.length != 2) {
+        throw new BulkEditException(emailString + " is not valid email address");
+      }
+      localPart = tokens[0];
+      domain = tokens[1];
+    }
+
+    public boolean domainMatch(String value) {
+      return domain.equals(value);
+    }
+
+    public String asStringWithDomain(String value) {
+      return String.join("@", localPart, value);
+    }
+  }
+}

--- a/src/test/java/org/folio/dew/service/update/EmailUpdateStrategyTest.java
+++ b/src/test/java/org/folio/dew/service/update/EmailUpdateStrategyTest.java
@@ -1,0 +1,92 @@
+package org.folio.dew.service.update;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.folio.dew.domain.dto.UserContentUpdate;
+import org.folio.dew.domain.dto.UserContentUpdateAction;
+import org.folio.dew.domain.dto.UserFormat;
+import org.folio.dew.error.BulkEditException;
+import org.folio.dew.service.EmailUpdateStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+class EmailUpdateStrategyTest {
+  private final EmailUpdateStrategy updateStrategy = new EmailUpdateStrategy();
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldUpdateEmailIfDomainMatch(boolean isPreview) {
+    var userFormat = new UserFormat().withEmail("test@somedomain.com");
+    var contentUpdate = new UserContentUpdate()
+      .option(UserContentUpdate.OptionEnum.EMAIL_ADDRESS)
+      .actions(List.of(new UserContentUpdateAction()
+        .name(UserContentUpdateAction.NameEnum.FIND)
+        .value("somedomain.com"),
+        new UserContentUpdateAction()
+          .name(UserContentUpdateAction.NameEnum.REPLACE_WITH)
+          .value("newdomain.com")
+        ));
+
+    var updatedUserFormat = updateStrategy.applyUpdate(userFormat, contentUpdate, isPreview);
+
+    assertThat(updatedUserFormat.getEmail(), equalTo("test@newdomain.com"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldNotUpdateEmailIfDomainDoesNotMatch(boolean isPreview) {
+    var userFormat = new UserFormat().withEmail("test@somedomain.com");
+    var contentUpdate = new UserContentUpdate()
+      .option(UserContentUpdate.OptionEnum.EMAIL_ADDRESS)
+      .actions(List.of(new UserContentUpdateAction()
+          .name(UserContentUpdateAction.NameEnum.FIND)
+          .value("another.com"),
+        new UserContentUpdateAction()
+          .name(UserContentUpdateAction.NameEnum.REPLACE_WITH)
+          .value("newdomain.com")
+      ));
+
+    var updatedUserFormat = updateStrategy.applyUpdate(userFormat, contentUpdate, isPreview);
+
+    assertThat(updatedUserFormat.getEmail(), equalTo("test@somedomain.com"));
+  }
+
+  @Test
+  void shouldNotUpdateEmailIfEmailIsNotValid() {
+    var userFormat = new UserFormat().withEmail("test.somedomain.com");
+    var contentUpdate = new UserContentUpdate()
+      .option(UserContentUpdate.OptionEnum.EMAIL_ADDRESS)
+      .actions(List.of(new UserContentUpdateAction()
+          .name(UserContentUpdateAction.NameEnum.FIND)
+          .value("somedomain.com"),
+        new UserContentUpdateAction()
+          .name(UserContentUpdateAction.NameEnum.REPLACE_WITH)
+          .value("newdomain.com")
+      ));
+
+    assertThrows(BulkEditException.class, () -> updateStrategy.applyUpdate(userFormat, contentUpdate, false));
+  }
+
+  @Test
+  void shouldReturnUnmodifiedUserFormatForPreviewIfEmailIsNotValid() {
+    var userFormat = new UserFormat().withEmail("test.somedomain.com");
+    var contentUpdate = new UserContentUpdate()
+      .option(UserContentUpdate.OptionEnum.EMAIL_ADDRESS)
+      .actions(List.of(new UserContentUpdateAction()
+          .name(UserContentUpdateAction.NameEnum.FIND)
+          .value("somedomain.com"),
+        new UserContentUpdateAction()
+          .name(UserContentUpdateAction.NameEnum.REPLACE_WITH)
+          .value("newdomain.com")
+      ));
+
+    var updatedUserFormat = updateStrategy.applyUpdate(userFormat, contentUpdate, true);
+
+    assertThat(updatedUserFormat.getEmail(), equalTo("test.somedomain.com"));
+    }
+}

--- a/src/test/java/org/folio/dew/service/update/EmailUpdateStrategyTest.java
+++ b/src/test/java/org/folio/dew/service/update/EmailUpdateStrategyTest.java
@@ -11,6 +11,7 @@ import org.folio.dew.error.BulkEditException;
 import org.folio.dew.service.EmailUpdateStrategy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
@@ -38,20 +39,20 @@ class EmailUpdateStrategyTest {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void shouldNotUpdateEmailIfDomainDoesNotMatch(boolean isPreview) {
+  @CsvSource({"true,another.com", "true,SomeDomain.com", "false,another.com", "false,SomeDomain.com"})
+  void shouldNotUpdateEmailIfDomainDoesNotMatch(String isPreview, String findValue) {
     var userFormat = new UserFormat().withEmail("test@somedomain.com");
     var contentUpdate = new UserContentUpdate()
       .option(UserContentUpdate.OptionEnum.EMAIL_ADDRESS)
       .actions(List.of(new UserContentUpdateAction()
           .name(UserContentUpdateAction.NameEnum.FIND)
-          .value("another.com"),
+          .value(findValue),
         new UserContentUpdateAction()
           .name(UserContentUpdateAction.NameEnum.REPLACE_WITH)
           .value("newdomain.com")
       ));
 
-    var updatedUserFormat = updateStrategy.applyUpdate(userFormat, contentUpdate, isPreview);
+    var updatedUserFormat = updateStrategy.applyUpdate(userFormat, contentUpdate, Boolean.parseBoolean(isPreview));
 
     assertThat(updatedUserFormat.getEmail(), equalTo("test@somedomain.com"));
   }


### PR DESCRIPTION
[MODEXPW-189](https://issues.folio.org/browse/MODEXPW-189) - users-in-app-update: E-mails bulk-edit updating

## Purpose
The following business case should be covered: change e-mail address for all affected users when the institution domain changes. From the technical point of view one need to replace text in the e-mail address for all adresses that contain this text.

## Approach
* Implemented email update component
* Added unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
