### PR TITLE
MODEXPW-180 - users-in-app-update: Update BulkEditController to support USERS content update

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -60,6 +60,14 @@
         },
         {
           "methods": [ "POST" ],
+          "pathPattern": "/bulk-edit/{id}/user-content-update/upload",
+          "permissionsRequired": [ "bulk-edit.users-content-update.collection.post" ],
+          "modulePermissions": [
+
+          ]
+        },
+        {
+          "methods": [ "POST" ],
           "pathPattern": "/bulk-edit/{id}/start",
           "permissionsRequired": [ "bulk-edit.start.item.post" ],
           "modulePermissions": [
@@ -207,6 +215,11 @@
       "description" : "Upload collection of item content updates"
     },
     {
+      "permissionName" : "bulk-edit.users-content-update.collection.post",
+      "displayName" : "upload users content update collection",
+      "description" : "Upload collection of user content updates"
+    },
+    {
       "permissionName" : "bulk-edit.preview.updated-items.collection.get",
       "displayName" : "download updated items preview csv",
       "description" : "Download csv of preview updated items"
@@ -244,6 +257,7 @@
       "subPermissions" : [
         "bulk-edit.item.post",
         "bulk-edit.items-content-update.collection.post",
+        "bulk-edit.users-content-update.collection.post",
         "bulk-edit.preview.updated-items.collection.get",
         "bulk-edit.start.item.post",
         "bulk-edit.roll-back.item.post",

--- a/src/main/java/org/folio/dew/batch/JobCompletionNotificationListener.java
+++ b/src/main/java/org/folio/dew/batch/JobCompletionNotificationListener.java
@@ -17,6 +17,7 @@ import static org.folio.dew.utils.Constants.FILE_NAME;
 import static org.folio.dew.utils.Constants.CSV_EXTENSION;
 import static org.folio.dew.utils.Constants.UPDATED_PREFIX;
 import static org.folio.dew.utils.Constants.EXPORT_TYPE;
+import static org.folio.dew.utils.Constants.INITIAL_PREFIX;
 
 import java.io.File;
 import java.io.IOException;
@@ -286,7 +287,8 @@ public class JobCompletionNotificationListener extends JobExecutionListenerSuppo
     if (isBulkEditIdentifiersJob(jobExecution)) {
       return null;
     }
-    return FilenameUtils.getName(path).replace(MATCHED_RECORDS, CHANGED_RECORDS).replace(UPDATED_PREFIX, EMPTY);
+    return FilenameUtils.getName(path).replace(MATCHED_RECORDS, CHANGED_RECORDS).replace(UPDATED_PREFIX, EMPTY)
+      .replace(INITIAL_PREFIX, EMPTY);
   }
 
   private String prepareChangedUsersFile(String path, String jobId) {

--- a/src/main/java/org/folio/dew/batch/bulkedit/jobs/updatejob/BulkEditUpdateUserRecordsJobConfig.java
+++ b/src/main/java/org/folio/dew/batch/bulkedit/jobs/updatejob/BulkEditUpdateUserRecordsJobConfig.java
@@ -91,7 +91,7 @@ public class BulkEditUpdateUserRecordsJobConfig {
     LineMapper<UserFormat> userLineMapper = JobConfigReaderHelper.createUserLineMapper();
     return new FlatFileItemReaderBuilder<UserFormat>()
       .name("userReader")
-      .resource(isEmpty(updatedFileName) ? new FileSystemResource(fileName) : new InputStreamResource(repository.getObject(UPDATED_FILE_NAME)))
+      .resource(isEmpty(updatedFileName) ? new FileSystemResource(fileName) : new InputStreamResource(repository.getObject(updatedFileName)))
       .linesToSkip(1)
       .lineMapper(userLineMapper)
       .build();

--- a/src/main/java/org/folio/dew/controller/BulkEditController.java
+++ b/src/main/java/org/folio/dew/controller/BulkEditController.java
@@ -407,8 +407,9 @@ public class BulkEditController implements JobIdApi {
     if (!fileName.contains(CSV_EXTENSION)) fileName += CSV_EXTENSION;
     try {
       Reader inputReader;
-      if (Files.notExists(Path.of(fileName)) && repository.containsFile(fileName = PREVIEW_PREFIX + FilenameUtils.getName(fileName))) {
-        inputReader = new InputStreamReader(repository.getObject(fileName));
+      var minioFileName = PREVIEW_PREFIX + FilenameUtils.getName(fileName);
+      if (Files.notExists(Path.of(fileName)) && repository.containsFile(minioFileName)) {
+        inputReader = new InputStreamReader(repository.getObject(minioFileName));
       } else {
         inputReader = new FileReader(fileName);
       }

--- a/src/main/java/org/folio/dew/controller/BulkEditController.java
+++ b/src/main/java/org/folio/dew/controller/BulkEditController.java
@@ -13,6 +13,7 @@ import static org.folio.dew.domain.dto.JobParameterNames.PREVIEW_FILE_NAME;
 import static org.folio.dew.domain.dto.JobParameterNames.QUERY;
 import static org.folio.dew.domain.dto.JobParameterNames.TEMP_OUTPUT_FILE_PATH;
 import static org.folio.dew.domain.dto.JobParameterNames.UPDATED_FILE_NAME;
+import org.folio.dew.domain.dto.UserContentUpdateCollection;
 import static org.folio.dew.utils.BulkEditProcessorHelper.getMatchPattern;
 import static org.folio.dew.utils.BulkEditProcessorHelper.resolveIdentifier;
 import static org.folio.dew.utils.Constants.CSV_EXTENSION;
@@ -23,7 +24,6 @@ import static org.folio.dew.utils.Constants.IDENTIFIER_TYPE;
 import static org.folio.dew.utils.Constants.MATCHED_RECORDS;
 import static org.folio.dew.utils.Constants.NO_CHANGE_MESSAGE;
 import static org.folio.dew.utils.Constants.PATH_SEPARATOR;
-import static org.folio.dew.utils.Constants.QUOTE;
 import static org.folio.dew.utils.Constants.TMP_DIR_PROPERTY;
 import static org.folio.dew.utils.Constants.TOTAL_CSV_LINES;
 import static org.folio.dew.utils.CsvHelper.countLines;
@@ -76,6 +76,7 @@ import org.folio.dew.service.BulkEditProcessingErrorsService;
 import org.folio.dew.service.BulkEditRollBackService;
 import org.folio.dew.service.UpdatesResult;
 import org.folio.dew.service.JobCommandsReceiverService;
+import org.folio.dew.service.BulkEditUserContentUpdateService;
 import org.folio.dew.utils.CsvHelper;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
@@ -123,6 +124,7 @@ public class BulkEditController implements JobIdApi {
   private final BulkEditProcessingErrorsService bulkEditProcessingErrorsService;
   private final List<Job> jobs;
   private final BulkEditItemContentUpdateService itemContentUpdateService;
+  private final BulkEditUserContentUpdateService userContentUpdateService;
   private final BulkEditParseService bulkEditParseService;
   private final MinIOObjectStorageRepository repository;
   private final FolioModuleMetadata folioModuleMetadata;
@@ -151,7 +153,21 @@ public class BulkEditController implements JobIdApi {
   }
 
   @Override
-  public ResponseEntity<Object> getPreviewUsersByJobId(@ApiParam(value = "UUID of the JobCommand", required = true) @PathVariable("jobId") UUID jobId, @NotNull @ApiParam(value = "The numbers of items to return", required = true) @Valid @RequestParam(value = "limit") Integer limit) {
+  public ResponseEntity<UserCollection> postUserContentUpdates(@ApiParam(value = "UUID of the JobCommand",required=true) @PathVariable("jobId") UUID jobId, @ApiParam(value = "" ,required=true )  @Valid @RequestBody UserContentUpdateCollection contentUpdateCollection, @ApiParam(value = "The numbers of records to return") @Valid @RequestParam(value = "limit", required = false) Integer limit) {
+    bulkEditProcessingErrorsService.removeTemporaryErrorStorage(jobId.toString());
+    var jobCommand = getJobCommandById(jobId.toString());
+    if (nonNull(jobCommand.getIdentifierType())) {
+      jobCommand.setJobParameters(new JobParametersBuilder(jobCommand.getJobParameters())
+        .addString(IDENTIFIER_TYPE, jobCommand.getIdentifierType().getValue())
+        .toJobParameters());
+    }
+    var updatesResult = userContentUpdateService.process(jobCommand, contentUpdateCollection);
+    log.info("postUserContentUpdate: {}", updatesResult.getUsersForPreview());
+    return new ResponseEntity<>(prepareUserContentUpdateResponse(updatesResult, limit), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<UserCollection> getPreviewUsersByJobId(@ApiParam(value = "UUID of the JobCommand", required = true) @PathVariable("jobId") UUID jobId, @NotNull @ApiParam(value = "The numbers of items to return", required = true) @Valid @RequestParam(value = "limit") Integer limit) {
     var jobCommand = getJobCommandById(jobId.toString());
     if (BULK_EDIT_IDENTIFIERS == jobCommand.getExportType()) {
       var fileName = FilenameUtils.getName(jobCommand.getJobParameters().getString(TEMP_OUTPUT_FILE_PATH)) + CSV_EXTENSION;
@@ -348,6 +364,14 @@ public class BulkEditController implements JobIdApi {
         .map(bulkEditParseService::mapItemFormatToItem)
         .collect(Collectors.toList());
       return new ItemCollection().items(items).totalRecords(updatesResult.getTotal());
+  }
+
+  private UserCollection prepareUserContentUpdateResponse(UpdatesResult<UserFormat> updatesResult, Integer limit) {
+    var users = updatesResult.getUsersForPreview().stream()
+      .limit(isNull(limit) ? Integer.MAX_VALUE : limit)
+      .map(bulkEditParseService::mapUserFormatToUser)
+      .collect(Collectors.toList());
+    return new UserCollection().users(users).totalRecords(updatesResult.getTotal());
   }
 
   private String buildPreviewUsersQueryFromJobCommand(JobCommand jobCommand, int limit) {

--- a/src/main/java/org/folio/dew/repository/MinIOObjectStorageRepository.java
+++ b/src/main/java/org/folio/dew/repository/MinIOObjectStorageRepository.java
@@ -103,9 +103,6 @@ public class MinIOObjectStorageRepository {
       InvalidKeyException, NoSuchAlgorithmException, XmlParserException, ErrorResponseException {
     log.info("Uploading object {},filename {},downloadFilename {},contentType {}.", object, filename, downloadFilename,
         contentType);
-    if (Files.notExists(Path.of(filename))) {
-      downloadObject(filename, filename);
-    }
     ObjectWriteResponse result = client.uploadObject(
         createArgs(UploadObjectArgs.builder().filename(filename), object, downloadFilename, contentType));
 

--- a/src/main/java/org/folio/dew/repository/MinIOObjectStorageRepository.java
+++ b/src/main/java/org/folio/dew/repository/MinIOObjectStorageRepository.java
@@ -32,11 +32,10 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.sql.Array;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,6 @@ import io.minio.messages.Item;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.dew.config.properties.MinIoProperties;
 import org.springframework.http.HttpHeaders;
@@ -105,6 +103,9 @@ public class MinIOObjectStorageRepository {
       InvalidKeyException, NoSuchAlgorithmException, XmlParserException, ErrorResponseException {
     log.info("Uploading object {},filename {},downloadFilename {},contentType {}.", object, filename, downloadFilename,
         contentType);
+    if (Files.notExists(Path.of(filename))) {
+      downloadObject(filename, filename);
+    }
     ObjectWriteResponse result = client.uploadObject(
         createArgs(UploadObjectArgs.builder().filename(filename), object, downloadFilename, contentType));
 

--- a/src/main/java/org/folio/dew/service/BulkEditUserContentUpdateService.java
+++ b/src/main/java/org/folio/dew/service/BulkEditUserContentUpdateService.java
@@ -48,7 +48,7 @@ public class BulkEditUserContentUpdateService {
         .addString(PREVIEW_FILE_NAME, previewFileName)
         .toJobParameters());
       jobCommand.setExportType(BULK_EDIT_UPDATE);
-      return new UpdatesResult<UserFormat>().withTotal(userFormats.size()).withItemsForPreview(contentUpdatedUsers.getPreview());
+      return new UpdatesResult<UserFormat>().withTotal(userFormats.size()).withUsersForPreview(contentUpdatedUsers.getPreview());
     } catch (Exception e) {
       var msg = String.format("I/O exception for job id %s, reason: %s", jobCommand.getId(), e.getMessage());
       log.error(msg);

--- a/src/main/java/org/folio/dew/service/UpdatesResult.java
+++ b/src/main/java/org/folio/dew/service/UpdatesResult.java
@@ -16,4 +16,5 @@ import java.util.List;
 public class UpdatesResult<T> {
   private int total;
   private List<T> itemsForPreview;
+  private List<T> usersForPreview;
 }

--- a/src/main/resources/swagger.api/bulk-edit.yaml
+++ b/src/main/resources/swagger.api/bulk-edit.yaml
@@ -59,6 +59,60 @@ paths:
                 $ref: "#/components/examples/errors"
               schema:
                 $ref: "#/components/schemas/errors"
+  /{jobId}/user-content-update/upload:
+    post:
+      description: Upload user content updates
+      operationId: postUserContentUpdates
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          description: UUID of the JobCommand
+          schema:
+            $ref: "#/components/schemas/UUID"
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+          description: The numbers of records to return
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/userContentUpdateCollection"
+      responses:
+        "200":
+          description: Collection of users for preview
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/userCollection"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              example:
+                $ref: "#/components/examples/errors"
+              schema:
+                $ref: "#/components/schemas/errors"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              example:
+                $ref: "#/components/examples/errors"
+              schema:
+                $ref: "#/components/schemas/errors"
+        "500":
+          description: Internal server errors, e.g. due to misconfiguration
+          content:
+            application/json:
+              example:
+                $ref: "#/components/examples/errors"
+              schema:
+                $ref: "#/components/schemas/errors"
   /{jobId}/preview/updated-items/download:
     get:
       description: Download preview as csv-file
@@ -366,7 +420,7 @@ components:
     departmentCollection:
       $ref: '../../../../folio-export-common/schemas/user/departmentCollection.json#/DepartmentCollection'
     userCollection:
-      $ref: '../../../../folio-export-common/schemas/user/userCollection.json'
+      $ref: '../../../../folio-export-common/schemas/user/userCollection.json#/UserCollection'
     itemCollection:
       $ref: '../../../../folio-export-common/schemas/inventory/itemCollection.json#/ItemCollection'
     callNumberType:

--- a/src/test/java/org/folio/dew/controller/BulkEditControllerTest.java
+++ b/src/test/java/org/folio/dew/controller/BulkEditControllerTest.java
@@ -1122,6 +1122,11 @@ class BulkEditControllerTest extends BaseBatchTest {
         assertEquals("789@NEWexample3.com", u.getPersonal().getEmail());
       }
     });
+    mockMvc.perform(get(format(PREVIEW_USERS_URL_TEMPLATE, jobId))
+      .headers(defaultHeaders())
+      .queryParam(LIMIT, String.valueOf(10)))
+      .andExpect(status().isOk())
+      .andReturn();
   }
 
   @Test

--- a/src/test/java/org/folio/dew/service/BulkEditUserContentUpdateServiceTest.java
+++ b/src/test/java/org/folio/dew/service/BulkEditUserContentUpdateServiceTest.java
@@ -61,8 +61,8 @@ class BulkEditUserContentUpdateServiceTest extends BaseBatchTest {
 
     var res = contentUpdateService.process(jobCommand, contentUpdates);
 
-    assertThat(res.getItemsForPreview(), hasSize(2));
-    assertThat(res.getItemsForPreview().stream().allMatch(userFormat -> "new patron group".equals(userFormat.getPatronGroup())), is(true));
+    assertThat(res.getUsersForPreview(), hasSize(2));
+    assertThat(res.getUsersForPreview().stream().allMatch(userFormat -> "new patron group".equals(userFormat.getPatronGroup())), is(true));
 
     assertThat(minIOObjectStorageRepository.containsFile(updatedFileName), is(true));
     assertThat(minIOObjectStorageRepository.containsFile(previewFileName), is(true));

--- a/src/test/resources/output/expected_errors_for_clear_patron_group.json
+++ b/src/test/resources/output/expected_errors_for_clear_patron_group.json
@@ -1,0 +1,23 @@
+{
+  "errors": [
+    {
+      "message": "123,Patron group cannot be cleared",
+      "type": "BULK_EDIT_ERROR",
+      "code": null,
+      "parameters": null
+    },
+    {
+      "message": "456,Patron group cannot be cleared",
+      "type": "BULK_EDIT_ERROR",
+      "code": null,
+      "parameters": null
+    },
+    {
+      "message": "789,Patron group cannot be cleared",
+      "type": "BULK_EDIT_ERROR",
+      "code": null,
+      "parameters": null
+    }
+  ],
+  "total_records": 3
+}


### PR DESCRIPTION
[MODEXPW-180](https://issues.folio.org/browse/MODEXPW-180) - users-in-app-update: Update BulkEditController to support USERS content update

## Purpose
BulkEditController should be updated to support UserContentUpdateCollection.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
