### PR TITLE
MODEXPW-263 - EHoldings export: Missing .csv file format in file name

### DIFF
--- a/src/main/java/org/folio/dew/service/FileNameResolver.java
+++ b/src/main/java/org/folio/dew/service/FileNameResolver.java
@@ -43,9 +43,9 @@ public class FileNameResolver {
         var recordId = config.getRecordId();
         String fileSuffix;
         if (config.getRecordType() == EHoldingsExportConfig.RecordTypeEnum.RESOURCE) {
-          fileSuffix = String.format("%s_resource", recordId);
+          fileSuffix = String.format("%s_resource.csv", recordId);
         } else {
-          fileSuffix = String.format("%s_package", recordId);
+          fileSuffix = String.format("%s_package.csv", recordId);
         }
         return String.format("%s%s_%s", workDir, dateFormat.format(new Date()), fileSuffix);
       } catch (JsonProcessingException e) {

--- a/src/test/java/org/folio/dew/service/FileNameResolverTest.java
+++ b/src/test/java/org/folio/dew/service/FileNameResolverTest.java
@@ -1,0 +1,58 @@
+package org.folio.dew.service;
+
+import static org.folio.dew.domain.dto.ExportType.E_HOLDINGS;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.folio.de.entity.JobCommand;
+import org.folio.dew.domain.dto.EHoldingsExportConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+
+@ExtendWith(MockitoExtension.class)
+class FileNameResolverTest {
+  @Mock
+  private ObjectMapper objectMapper;
+  @InjectMocks
+  private FileNameResolver service;
+
+  @SneakyThrows
+  @MethodSource("recordTypes")
+  @ParameterizedTest
+  void resolve_success_eHoldings_recordTypes(EHoldingsExportConfig.RecordTypeEnum recordType, String endFileName) {
+    var config = new EHoldingsExportConfig()
+      .recordId("test_id")
+      .recordType(recordType);
+    var jobCommand = new JobCommand();
+    jobCommand.setExportType(E_HOLDINGS);
+    var jobParameters = new JobParameters(Map.of("eHoldingsExportConfig", new JobParameter("any")));
+    jobCommand.setJobParameters(jobParameters);
+    when(objectMapper.readValue(anyString(), eq(EHoldingsExportConfig.class)))
+      .thenReturn(config);
+
+    var result = service.resolve(jobCommand, "", "any_job_id");
+
+    assertTrue(result.endsWith("test_id_" + endFileName));
+  }
+
+  public static Stream<Arguments> recordTypes() {
+    return Stream.of(
+      arguments(EHoldingsExportConfig.RecordTypeEnum.PACKAGE, "package.csv"),
+      arguments(EHoldingsExportConfig.RecordTypeEnum.RESOURCE, "resource.csv"));
+  }
+}


### PR DESCRIPTION
## Purpose
As described in [MODEXPW-263](https://issues.folio.org/browse/MODEXPW-263), missing .csv file format in file name for EHoldings export.

## Approach
Fixed in FileNameResolver class
