### PR TITLE
MODEXPW-301 Fix default value for `E_HOLDINGS_BATCH_KB_EBSCO_CHUNK_SIZE`

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,7 +94,7 @@ application:
     size: ${BUCKET_SIZE:50}
   e-holdings-batch:
     job-chunk-size: ${E_HOLDINGS_BATCH_JOB_CHUNK_SIZE:100}
-    kb-ebsco-chunk-size: ${E_HOLDINGS_BATCH_KB_EBSCO_CHUNK_SIZE:105}
+    kb-ebsco-chunk-size: ${E_HOLDINGS_BATCH_KB_EBSCO_CHUNK_SIZE:100}
 folio:
   tenant:
     validation:


### PR DESCRIPTION
## Approach
Set default value for `E_HOLDINGS_BATCH_KB_EBSCO_CHUNK_SIZE` to 100

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  