### PR TITLE
MODEXPW-318 - Export jobs is failed when "Package fields to export" or "Titles fields to export" are without chosen options in multi-select

### DIFF
--- a/src/main/java/org/folio/dew/batch/eholdings/EHoldingsCsvFileWriter.java
+++ b/src/main/java/org/folio/dew/batch/eholdings/EHoldingsCsvFileWriter.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.commons.collections.CollectionUtils;
 import org.folio.de.entity.EHoldingsPackage;
 import org.folio.dew.domain.dto.EHoldingsExportConfig;
 import org.folio.dew.domain.dto.eholdings.EHoldingsResourceExportFormat;
@@ -36,7 +37,6 @@ import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.support.AbstractFileItemWriter;
 import org.springframework.beans.BeanWrapperImpl;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ClassUtils;
@@ -47,8 +47,7 @@ public class EHoldingsCsvFileWriter extends AbstractFileItemWriter<EHoldingsReso
   private int maxPackageNotesLength;
   private int maxTitleNotesLength;
   private final String tempOutputFilePath;
-  @Autowired
-  private LocalFilesStorage localFilesStorage;
+  private final LocalFilesStorage localFilesStorage;
   private final EHoldingsPackageRepository packageRepository;
   private final EHoldingsExportConfig exportConfig;
   private final EHoldingsToExportFormatMapper mapper;
@@ -56,13 +55,15 @@ public class EHoldingsCsvFileWriter extends AbstractFileItemWriter<EHoldingsReso
   public EHoldingsCsvFileWriter(@Value("#{jobParameters['tempOutputFilePath']}") String tempOutputFilePath,
                                 EHoldingsExportConfig exportConfig,
                                 EHoldingsPackageRepository packageRepository,
-                                EHoldingsToExportFormatMapper mapper) {
+                                EHoldingsToExportFormatMapper mapper,
+                                LocalFilesStorage localFilesStorage) {
     setEholdingsResource(tempOutputFilePath);
     this.setExecutionContextName(ClassUtils.getShortName(EHoldingsCsvFileWriter.class));
     this.tempOutputFilePath = tempOutputFilePath;
     this.packageRepository = packageRepository;
     this.exportConfig = exportConfig;
     this.mapper = mapper;
+    this.localFilesStorage = localFilesStorage;
   }
 
   private void setEholdingsResource(String tempOutputFilePath) {
@@ -80,8 +81,10 @@ public class EHoldingsCsvFileWriter extends AbstractFileItemWriter<EHoldingsReso
 
     writePackage(stepExecution.getJobExecutionId());
 
-    var resourceHeaders = getHeader(exportConfig.getTitleFields()) + lineSeparator;
-    writeString(resourceHeaders);
+    if (CollectionUtils.isNotEmpty(exportConfig.getTitleFields())) {
+      var resourceHeaders = getHeader(exportConfig.getTitleFields()) + lineSeparator;
+      writeString(resourceHeaders);
+    }
   }
 
   @Override
@@ -107,19 +110,22 @@ public class EHoldingsCsvFileWriter extends AbstractFileItemWriter<EHoldingsReso
   private void writePackage(Long jobExecutionId) throws IOException {
 
     var packageFields = exportConfig.getPackageFields();
-    var packageHeader = getHeader(packageFields) + lineSeparator;
-    writeString(packageHeader);
+    if (CollectionUtils.isNotEmpty(packageFields)) {
+      var packageHeader = getHeader(packageFields) + lineSeparator;
+      writeString(packageHeader);
 
-    var recordId = exportConfig.getRecordId();
-    var packageId = exportConfig.getRecordType() == PACKAGE ? recordId : recordId.split("-\\d+$")[0];
-    var packageComposedId = new EHoldingsPackage.PackageId();
-    packageComposedId.setId(packageId);
-    packageComposedId.setJobExecutionId(jobExecutionId);
-    var eHoldingsPackage = packageRepository.findById(packageComposedId).orElse(null);
-    var packageExportFormat = mapper.convertToExportFormat(eHoldingsPackage);
+      var recordId = exportConfig.getRecordId();
+      var packageId = exportConfig.getRecordType() == PACKAGE ? recordId : recordId.split("-\\d+$")[0];
+      var packageComposedId = new EHoldingsPackage.PackageId();
+      packageComposedId.setId(packageId);
+      packageComposedId.setJobExecutionId(jobExecutionId);
+      var eHoldingsPackage = packageRepository.findById(packageComposedId).orElse(null);
+      var packageExportFormat = mapper.convertToExportFormat(eHoldingsPackage);
 
-    var packageRow = getItemRow(maxPackageNotesLength, packageExportFormat, exportConfig.getPackageFields()) + lineSeparator;
-    writeString(packageRow);
+      var packageRow =
+        getItemRow(maxPackageNotesLength, packageExportFormat, exportConfig.getPackageFields()) + lineSeparator;
+      writeString(packageRow);
+    }
   }
 
   private void writeString(String str) throws IOException {

--- a/src/test/java/org/folio/dew/batch/eholdings/EHoldingsCsvFileWriterTest.java
+++ b/src/test/java/org/folio/dew/batch/eholdings/EHoldingsCsvFileWriterTest.java
@@ -31,20 +31,28 @@ import org.springframework.batch.item.ExecutionContext;
 
 @ExtendWith(MockitoExtension.class)
 class EHoldingsCsvFileWriterTest {
-  @Mock private LocalFilesStorage localFilesStorage;
-  @Mock private EHoldingsPackageRepository packageRepository;
-  @Mock private EHoldingsExportConfig exportConfig;
-  @Mock private EHoldingsToExportFormatMapper mapper;
-  @Mock  private StepExecution stepExecution;
-  @Mock private JobExecution jobExecution;
-  @Mock private ExecutionContext executionContext;
+  @Mock
+  private LocalFilesStorage localFilesStorage;
+  @Mock
+  private EHoldingsPackageRepository packageRepository;
+  @Mock
+  private EHoldingsExportConfig exportConfig;
+  @Mock
+  private EHoldingsToExportFormatMapper mapper;
+  @Mock
+  private StepExecution stepExecution;
+  @Mock
+  private JobExecution jobExecution;
+  @Mock
+  private ExecutionContext executionContext;
 
- private EHoldingsCsvFileWriter eHoldingsCsvFileWriter;
+  private EHoldingsCsvFileWriter eHoldingsCsvFileWriter;
 
   @SneakyThrows
   @BeforeEach
   void setUp() {
-    eHoldingsCsvFileWriter= new EHoldingsCsvFileWriter("any", exportConfig, packageRepository, mapper, localFilesStorage);
+    eHoldingsCsvFileWriter =
+      new EHoldingsCsvFileWriter("any", exportConfig, packageRepository, mapper, localFilesStorage);
     lenient().when(stepExecution.getJobExecutionId()).thenReturn(1L);
     lenient().when(stepExecution.getJobExecution()).thenReturn(jobExecution);
     lenient().when(jobExecution.getExecutionContext()).thenReturn(executionContext);
@@ -61,11 +69,11 @@ class EHoldingsCsvFileWriterTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideParameters")
-  void beforeStep_1(List<String> packageFields,
-                    List<String> titleFields,
-                    int localFileStorageInvocations,
-                    int packageRepositoryInvocations,
-                    int mapperInvocations) {
+  void testBeforeStep(List<String> packageFields,
+                      List<String> titleFields,
+                      int localFileStorageInvocations,
+                      int packageRepositoryInvocations,
+                      int mapperInvocations) {
 
     when(exportConfig.getPackageFields()).thenReturn(packageFields);
     when(exportConfig.getTitleFields()).thenReturn(titleFields);

--- a/src/test/java/org/folio/dew/batch/eholdings/EHoldingsCsvFileWriterTest.java
+++ b/src/test/java/org/folio/dew/batch/eholdings/EHoldingsCsvFileWriterTest.java
@@ -1,0 +1,90 @@
+package org.folio.dew.batch.eholdings;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.folio.de.entity.EHoldingsPackage;
+import org.folio.dew.domain.dto.EHoldingsExportConfig;
+import org.folio.dew.domain.dto.eholdings.EHoldingsPackageExportFormat;
+import org.folio.dew.repository.EHoldingsPackageRepository;
+import org.folio.dew.repository.LocalFilesStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+
+@ExtendWith(MockitoExtension.class)
+class EHoldingsCsvFileWriterTest {
+  @Mock private LocalFilesStorage localFilesStorage;
+  @Mock private EHoldingsPackageRepository packageRepository;
+  @Mock private EHoldingsExportConfig exportConfig;
+  @Mock private EHoldingsToExportFormatMapper mapper;
+  @Mock  private StepExecution stepExecution;
+  @Mock private JobExecution jobExecution;
+  @Mock private ExecutionContext executionContext;
+
+ private EHoldingsCsvFileWriter eHoldingsCsvFileWriter;
+
+  @SneakyThrows
+  @BeforeEach
+  void setUp() {
+    eHoldingsCsvFileWriter= new EHoldingsCsvFileWriter("any", exportConfig, packageRepository, mapper, localFilesStorage);
+    lenient().when(stepExecution.getJobExecutionId()).thenReturn(1L);
+    lenient().when(stepExecution.getJobExecution()).thenReturn(jobExecution);
+    lenient().when(jobExecution.getExecutionContext()).thenReturn(executionContext);
+    lenient().when(executionContext.getInt(anyString(), anyInt())).thenReturn(100);
+    lenient().when(exportConfig.getRecordId()).thenReturn("recordId");
+    doNothing().when(localFilesStorage).append(anyString(), any());
+    EHoldingsPackageExportFormat exportFormat = new EHoldingsPackageExportFormat();
+    exportFormat.setPackageId("packageId");
+    exportFormat.setPackageName("packageName");
+    lenient().when(packageRepository.findById(any())).thenReturn(Optional.of(new EHoldingsPackage()));
+    lenient().when(mapper.convertToExportFormat(any(EHoldingsPackage.class))).thenReturn(exportFormat);
+  }
+
+  @SneakyThrows
+  @ParameterizedTest
+  @MethodSource("provideParameters")
+  void beforeStep_1(List<String> packageFields,
+                    List<String> titleFields,
+                    int localFileStorageInvocations,
+                    int packageRepositoryInvocations,
+                    int mapperInvocations) {
+
+    when(exportConfig.getPackageFields()).thenReturn(packageFields);
+    when(exportConfig.getTitleFields()).thenReturn(titleFields);
+
+    eHoldingsCsvFileWriter.beforeStep(stepExecution);
+
+    verify(localFilesStorage, times(localFileStorageInvocations)).append(anyString(), any());
+    verify(packageRepository, times(packageRepositoryInvocations)).findById(any());
+    verify(mapper, times(mapperInvocations)).convertToExportFormat(any(EHoldingsPackage.class));
+  }
+
+  private static Stream<Arguments> provideParameters() {
+    return Stream.of(
+      Arguments.of(List.of(), List.of("Title Id", "Title Name"), 1, 0, 0),
+      Arguments.of(null, List.of("Title Id", "Title Name"), 1, 0, 0),
+      Arguments.of(List.of("packageId", "packageName"), List.of(), 2, 1, 1),
+      Arguments.of(List.of("packageId", "packageName"), null, 2, 1, 1),
+      Arguments.of(List.of("packageId", "packageName"), List.of("Title Id", "Title Name"), 3, 1, 1)
+    );
+  }
+
+}


### PR DESCRIPTION
## Purpose
Fix Export jobs is failed when "Package fields to export" or "Titles fields to export" are without chosen options in multi-select

## Approach
It's needed to add verification of package/title fields presence in `EHoldingsCsvFileWriter` before writing anything to file.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
## Learning
https://issues.folio.org/browse/MODEXPW-318