### PR TITLE
[MODEXPW-549] Improve bursar migration fallback logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2024-12-30 v3.3.6
+
+* [MODEXPW-549](https://folio-org.atlassian.net/browse/MODEXPW-549) Improve fallback logic for missing fields in bursar migration
+
 ## 2024-12-10 v3.3.5
 
 This release contains updates for missing interfaces.

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/service/BursarTokenFormatter.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/service/BursarTokenFormatter.java
@@ -94,23 +94,17 @@ public class BursarTokenFormatter {
     return processDateToken(currentDateTime, tokenDate.getValue(), tokenDate.getLengthControl());
   }
 
-  public static String formatFeeDateDataToken(BursarExportTokenFeeDate tokenFeeDate,
-      AccountWithAncillaryData accountWithAncillaryData) {
-    Date accountDate;
-    switch (tokenFeeDate.getProperty()) {
-    case CREATED -> accountDate = accountWithAncillaryData.getAccount()
-      .getDateCreated();
-    case UPDATED -> accountDate = accountWithAncillaryData.getAccount()
-      .getDateUpdated();
-    case DUE -> accountDate = accountWithAncillaryData.getAccount()
-      .getDueDate();
-    case RETURNED -> accountDate = accountWithAncillaryData.getAccount()
-      .getReturnedDate();
-    default -> {
-      log.error("[invalid fee date property: {}]", tokenFeeDate.getValue());
-      return tokenFeeDate.getPlaceholder();
-    }
-    }
+  public static String formatFeeDateDataToken(BursarExportTokenFeeDate tokenFeeDate, AccountWithAncillaryData accountWithAncillaryData) {
+    Date accountDate = switch (tokenFeeDate.getProperty()) {
+      case CREATED -> accountDate = accountWithAncillaryData.getAccount().getDateCreated();
+      case UPDATED -> accountDate = accountWithAncillaryData.getAccount().getDateUpdated();
+      case DUE -> accountDate = accountWithAncillaryData.getAccount().getDueDate();
+      case RETURNED -> accountDate = accountWithAncillaryData.getAccount().getReturnedDate();
+      default -> {
+        log.error("[invalid fee date property: {}]", tokenFeeDate.getValue());
+        yield null;
+      }
+    };
 
     if (accountDate == null) {
       return applyLengthControl(tokenFeeDate.getPlaceholder(), tokenFeeDate.getLengthControl());
@@ -269,7 +263,11 @@ public class BursarTokenFormatter {
     }
   }
 
-  public static String applyLengthControl(String input, @CheckForNull BursarExportTokenLengthControl lengthControl) {
+  public static String applyLengthControl(String input, BursarExportTokenLengthControl lengthControl) {
+    if (input == null) {
+      return applyLengthControl("", lengthControl);
+    }
+
     if (lengthControl == null) {
       return input;
     }

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/service/BursarTokenFormatter.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/service/BursarTokenFormatter.java
@@ -96,10 +96,10 @@ public class BursarTokenFormatter {
 
   public static String formatFeeDateDataToken(BursarExportTokenFeeDate tokenFeeDate, AccountWithAncillaryData accountWithAncillaryData) {
     Date accountDate = switch (tokenFeeDate.getProperty()) {
-      case CREATED -> accountDate = accountWithAncillaryData.getAccount().getDateCreated();
-      case UPDATED -> accountDate = accountWithAncillaryData.getAccount().getDateUpdated();
-      case DUE -> accountDate = accountWithAncillaryData.getAccount().getDueDate();
-      case RETURNED -> accountDate = accountWithAncillaryData.getAccount().getReturnedDate();
+      case CREATED -> accountWithAncillaryData.getAccount().getDateCreated();
+      case UPDATED -> accountWithAncillaryData.getAccount().getDateUpdated();
+      case DUE -> accountWithAncillaryData.getAccount().getDueDate();
+      case RETURNED -> accountWithAncillaryData.getAccount().getReturnedDate();
       default -> {
         log.error("[invalid fee date property: {}]", tokenFeeDate.getValue());
         yield null;


### PR DESCRIPTION
# [Jira MODEXPW-549](https://folio-org.atlassian.net/browse/MODEXPW-549)

## Purpose

As part of investigating this bug, I found some cases where it was possible for improper validation to cause a NullPointerException during application of a `LengthControl`. This provides an additional check to prevent these edge cases.