### PR TITLE
MODEXPW-554: Ramsons dependency upgrades fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.3.7</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -48,11 +48,11 @@
         <refresh-presigned-url.yaml.file>
           ${project.basedir}/src/main/resources/swagger.api/refresh-presigned-url.yaml
         </refresh-presigned-url.yaml.file>
-        <folio-spring-base.version>8.2.0</folio-spring-base.version>
+        <folio-spring-base.version>8.2.2</folio-spring-base.version>
         <folio-service-tools.version>3.1.0</folio-service-tools.version>
         <folio-spring-cql.version>8.2.0</folio-spring-cql.version>
         <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
-        <minio.version>8.5.9</minio.version>
+        <minio.version>8.5.15</minio.version>
         <openapi-generator.version>6.2.1</openapi-generator.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <hypersistence-utils-hibernate-63.version>3.7.3</hypersistence-utils-hibernate-63.version>
@@ -68,7 +68,7 @@
         <wiremock.version>2.27.2</wiremock.version>
         <marc4j.version>2.9.1</marc4j.version>
         <testcontainers.version>1.17.6</testcontainers.version>
-        <aws.sdk.version>2.25.13</aws.sdk.version>
+        <aws.sdk.version>2.29.47</aws.sdk.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEXPW-554

Upgrade Spring Boot from 3.2.3 to 3.3.7.

Note that OSS support for Spring Boot 3.2.x has ended 2024-11-23: https://spring.io/projects/spring-boot#support

Note that Ramsons requires Spring Boot 3.3.x: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5058042/Ramsons#Ramsons-ThirdPartyLibraries/Frameworks

Upgrade minio client from 8.5.9 to 8.5.15.

Upgrade folio-spring-base from 8.2.0 to 8.2.2.

Upgrade aws s3 client from 2.25.13 to 2.29.47.

The Spring Boot upgrade indirectly upgrades kafka-clients from 3.6.1 to 3.7.2 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-56128 Incorrect Implementation of Authentication Algorithm
* https://www.cve.org/CVERecord?id=CVE-2024-31141 Files or Directories Accessible to External Parties

The minio upgrade and the folio-spring-base upgrade indirectly upgrade bcprov-jdk18on from 1.77 to 1.78.1 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-30172 Infinite loop
* https://www.cve.org/CVERecord?id=CVE-2024-30171 Observable Discrepancy
* https://www.cve.org/CVERecord?id=CVE-2024-29857 Allocation of Resources Without Limits or Throttling

The Spring Boot upgrade and the folio-spring-base upgrade indirectly upgrade spring-webmvc from 6.1.4 to 6.1.16 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-38816 Path Traversal
* https://www.cve.org/CVERecord?id=CVE-2024-38819 Path Traversal

The Spring Boot upgrade and the folio-spring-base upgrade indirectly upgrade tomcat-embed-core from 10.1.19 to 10.1.34 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-38286 Allocation of Resources Without Limits or Throttling
* https://www.cve.org/CVERecord?id=CVE-2024-34750 Insufficient Session Expiration

The Spring Boot upgrade and the folio-spring-base upgrade indirectly upgrade spring-web from 6.1.4 to 6.1.16 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-22259 Open Redirect
* https://www.cve.org/CVERecord?id=CVE-2024-38809 Denial of Service (DoS)

The aws s3 client upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.116.Final fixing

* https://www.cve.org/CVERecord?id=CVE-2024-29025 Allocation of Resources Without Limits or Throttling

## Purpose
Make requires Ramsons dependency upgrades.

Make dependency upgrades to fix security vulnerabilities.

## Approach

Upgrade Spring Boot from 3.2.3 to 3.3.7.

Upgrade minio client from 8.5.9 to 8.5.15.

Upgrade folio-spring-base from 8.2.0 to 8.2.2.

Upgrade aws s3 client from 2.25.13 to 2.29.47.

## Learning
Before making a release upgrade the dependencies.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.