### PR TITLE
[MODEXPW-566]. Export details for successfully exported order are not populated on details pane

### DIFF
--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/EdifactExportJobConfig.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/EdifactExportJobConfig.java
@@ -44,6 +44,10 @@ public class EdifactExportJobConfig {
       .listener(ediExportJobCompletionListener)
       .start(mapToFileStep)
       .next(saveToMinIOStep)
+      // FTP and Export History are optional independent steps when the integration type is "Ordering"
+      // both FTP and/or Export History can be enabled, whereas when integration type is "Claiming"
+      // only the FTP can be used when the transmission method is "FTP". The syntax below tries to
+      // account for all branching choices within the limit of Spring Batch conditional flow
       .next(ftpStepDecider)
         .on(PROCESS.getStatus()).to(saveToFTPStep)
         .from(saveToFTPStep)

--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/EdifactExportJobConfig.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/EdifactExportJobConfig.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 import org.folio.dew.batch.acquisitions.jobs.decider.ExportHistoryTaskletDecider;
-import org.folio.dew.batch.acquisitions.jobs.decider.ExportStepDecision;
 import org.folio.dew.batch.acquisitions.jobs.decider.SaveToFileStorageTaskletDecider;
 import org.folio.dew.domain.dto.ExportType;
 import org.springframework.batch.core.Job;
@@ -22,6 +21,9 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static org.folio.dew.batch.acquisitions.jobs.decider.ExportStepDecision.PROCESS;
+import static org.folio.dew.batch.acquisitions.jobs.decider.ExportStepDecision.SKIP;
+
 @Configuration
 @Log4j2
 @RequiredArgsConstructor
@@ -32,8 +34,8 @@ public class EdifactExportJobConfig {
   private Job constructEdifactExportJob(JobBuilder jobBuilder,
                                         EdiExportJobCompletionListener ediExportJobCompletionListener,
                                         Step mapToFileStep,
-                                        Step saveToFTPStep,
                                         Step saveToMinIOStep,
+                                        Step saveToFTPStep,
                                         Step createExportHistoryRecordsStep,
                                         Map<String, JobExecutionDecider> optionalStepDeciders) {
     var ftpStepDecider = optionalStepDeciders.get(saveToFTPStep.getName());
@@ -42,27 +44,34 @@ public class EdifactExportJobConfig {
       .listener(ediExportJobCompletionListener)
       .start(mapToFileStep)
       .next(saveToMinIOStep)
-      .next(ftpStepDecider).on(ExportStepDecision.PROCESS.getStatus()).to(saveToFTPStep)
-      .from(ftpStepDecider).on(ExportStepDecision.SKIP.getStatus()).to(exportHistoryStepDecider)
-      .next(exportHistoryStepDecider).on(ExportStepDecision.PROCESS.getStatus()).to(createExportHistoryRecordsStep)
-      .from(exportHistoryStepDecider).on(ExportStepDecision.SKIP.getStatus()).end()
-      .end().build();
+      .next(ftpStepDecider)
+        .on(PROCESS.getStatus()).to(saveToFTPStep)
+        .from(saveToFTPStep)
+          .next(exportHistoryStepDecider)
+            .on(PROCESS.getStatus()).to(createExportHistoryRecordsStep)
+            .from(exportHistoryStepDecider).on(SKIP.getStatus()).end()
+        .from(ftpStepDecider).on(SKIP.getStatus()).to(exportHistoryStepDecider)
+      .next(exportHistoryStepDecider)
+        .on(PROCESS.getStatus()).to(createExportHistoryRecordsStep)
+        .from(exportHistoryStepDecider).on(SKIP.getStatus()).end()
+      .end()
+      .build();
   }
 
   @Bean
   public Job edifactOrdersExportJob(EdiExportJobCompletionListener ediExportJobCompletionListener, JobRepository jobRepository,
-                                    Step mapToEdifactOrdersStep, Step saveToFTPStep, Step saveToMinIOStep, Step createExportHistoryRecordsStep,
+                                    Step mapToEdifactOrdersStep, Step saveToMinIOStep, Step saveToFTPStep, Step createExportHistoryRecordsStep,
                                     Map<String, JobExecutionDecider> deciders) {
     return constructEdifactExportJob(new JobBuilder(ExportType.EDIFACT_ORDERS_EXPORT.getValue(), jobRepository),
-      ediExportJobCompletionListener, mapToEdifactOrdersStep, saveToFTPStep, saveToMinIOStep, createExportHistoryRecordsStep, deciders);
+      ediExportJobCompletionListener, mapToEdifactOrdersStep, saveToMinIOStep, saveToFTPStep, createExportHistoryRecordsStep, deciders);
   }
 
   @Bean
   public Job edifactClaimsExportJob(EdiExportJobCompletionListener ediExportJobCompletionListener, JobRepository jobRepository,
-                                    Step mapToEdifactClaimsStep, Step saveToFTPStep, Step saveToMinIOStep, Step createExportHistoryRecordsStep,
+                                    Step mapToEdifactClaimsStep, Step saveToMinIOStep, Step saveToFTPStep, Step createExportHistoryRecordsStep,
                                     Map<String, JobExecutionDecider> deciders) {
     return constructEdifactExportJob(new JobBuilder(ExportType.CLAIMS.getValue(), jobRepository),
-      ediExportJobCompletionListener, mapToEdifactClaimsStep, saveToFTPStep, saveToMinIOStep, createExportHistoryRecordsStep, deciders);
+      ediExportJobCompletionListener, mapToEdifactClaimsStep, saveToMinIOStep, saveToFTPStep, createExportHistoryRecordsStep, deciders);
   }
 
   @Bean
@@ -106,10 +115,13 @@ public class EdifactExportJobConfig {
   }
 
   @Bean
-  public Map<String, JobExecutionDecider> optionalStepDeciders(Step saveToFTPStep, Step createExportHistoryRecordsStep, ObjectMapper objectMapper) {
-    return Map.of(
-      saveToFTPStep.getName(), new SaveToFileStorageTaskletDecider(objectMapper, saveToFTPStep.getName()),
-      createExportHistoryRecordsStep.getName(), new ExportHistoryTaskletDecider(objectMapper, createExportHistoryRecordsStep.getName())
+  public Map<String, JobExecutionDecider> optionalStepDeciders(Step saveToFTPStep, Step createExportHistoryRecordsStep,
+                                                               ObjectMapper objectMapper) {
+    return Map.ofEntries(
+      Map.entry(saveToFTPStep.getName(),
+        new SaveToFileStorageTaskletDecider(objectMapper, saveToFTPStep.getName())),
+      Map.entry(createExportHistoryRecordsStep.getName(),
+        new ExportHistoryTaskletDecider(objectMapper, createExportHistoryRecordsStep.getName()))
     );
   }
 

--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/ExportHistoryTasklet.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/ExportHistoryTasklet.java
@@ -31,10 +31,10 @@ import org.springframework.stereotype.Component;
 
 import lombok.extern.log4j.Log4j2;
 
-@RequiredArgsConstructor
-@Component
-@StepScope
 @Log4j2
+@StepScope
+@Component
+@RequiredArgsConstructor
 public class ExportHistoryTasklet implements Tasklet {
 
   private final KafkaService kafkaService;
@@ -43,6 +43,7 @@ public class ExportHistoryTasklet implements Tasklet {
 
   @Value("#{jobParameters['jobId']}")
   private String jobId;
+
   @Override
   public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
     var exportHistory = buildExportHistory(chunkContext);

--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/SaveToFileStorageTasklet.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/SaveToFileStorageTasklet.java
@@ -23,10 +23,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
-@RequiredArgsConstructor
-@Component
-@StepScope
 @Log4j2
+@StepScope
+@Component
+@RequiredArgsConstructor
 public class SaveToFileStorageTasklet implements Tasklet {
 
   private static final String SFTP_PROTOCOL = "sftp://";

--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/decider/ExportHistoryTaskletDecider.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/decider/ExportHistoryTaskletDecider.java
@@ -19,8 +19,9 @@ public class ExportHistoryTaskletDecider extends ExportStepDecider {
 
   @Override
   public ExportStepDecision decide(VendorEdiOrdersExportConfig exportConfig, JobExecution jobExecution, StepExecution stepExecution) {
-    // Always execute if the integration type is not ORDERING, or execute for other integration types if the transmission method is FTP
+    // Always execute if the integration type is ORDERING
     if (exportConfig.getIntegrationType() == ORDERING) {
+      log.info("decide:: Processing step: {}", stepName);
       return ExportStepDecision.PROCESS;
     }
     log.info("decide:: Integration type is not ORDERING, skipping the step: {}", stepName);

--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/decider/SaveToFileStorageTaskletDecider.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/decider/SaveToFileStorageTaskletDecider.java
@@ -20,11 +20,12 @@ public class SaveToFileStorageTaskletDecider extends ExportStepDecider {
 
   @Override
   public ExportStepDecision decide(VendorEdiOrdersExportConfig exportConfig, JobExecution jobExecution, StepExecution stepExecution) {
-    // Always execute if the integration type is ORDERING, or other integration type if the transmission method is FTP
+    // Always execute if the integration type is ORDERING, or execute for other integration type if the transmission method is FTP
     if (exportConfig.getIntegrationType() == ORDERING || exportConfig.getTransmissionMethod() == FTP) {
+      log.info("decide:: Processing step: {}", stepName);
       return ExportStepDecision.PROCESS;
     }
-    log.info("decide:: Transmission method is not FTP, skipping the step: {}", stepName);
+    log.info("decide:: Integration type is not ORDERING or Transmission method is not FTP, skipping the step: {}", stepName);
     return ExportStepDecision.SKIP;
   }
 

--- a/src/main/java/org/folio/dew/batch/acquisitions/services/ConfigurationService.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/services/ConfigurationService.java
@@ -27,35 +27,26 @@ public class ConfigurationService {
   @Cacheable(cacheNames = "addressConfiguration")
   public String getAddressConfig(UUID shipToConfigId) {
     if (shipToConfigId == null) {
-      logger.warn("getAddressConfig:: 'shipTo' field of composite purchase order is null");
+      logger.warn("getAddressConfig:: shipToConfigId is null");
       return "";
     }
-
-    ModelConfiguration addressConfig;
+    ModelConfiguration config;
     try {
-      addressConfig = getConfigById(shipToConfigId.toString());
+      config = configurationClient.getConfigById(shipToConfigId.toString());
     } catch (NotFoundException e) {
-      logger.warn("getAddressConfig:: cannot find config by id: '{}'", shipToConfigId);
+      logger.warn("getAddressConfig:: Cannot find config by id: '{}'", shipToConfigId);
       return "";
     }
-    if (addressConfig.getValue() == null) {
-      logger.warn("getAddressConfig:: 'address config with id '{}' is not found", shipToConfigId);
+    if (config.getValue() == null) {
+      logger.warn("getAddressConfig:: Address on the config with id '{}' is not found", shipToConfigId);
       return "";
     }
     try {
-      JsonNode valueJsonObject = objectMapper.readTree(addressConfig.getValue());
+      JsonNode valueJsonObject = objectMapper.readTree(config.getValue());
       return valueJsonObject.has("address") ? valueJsonObject.get("address").asText() : "";
     } catch (JsonProcessingException e) {
-      logger.error("getAddressConfig:: Couldn't convert configValue: {} to json", addressConfig, e);
+      logger.error("getAddressConfig:: Cannot convert config value: {} to json", config, e);
       return "";
-    }
-  }
-
-  private ModelConfiguration getConfigById(String configId) {
-    try {
-      return configurationClient.getConfigById(configId);
-    } catch (NotFoundException e) {
-      throw new NotFoundException("Configuration entry not found for id: " + configId, e);
     }
   }
 }

--- a/src/test/java/org/folio/dew/batch/acquisitions/services/ConfigurationServiceTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/services/ConfigurationServiceTest.java
@@ -16,20 +16,20 @@ class ConfigurationServiceTest extends BaseBatchTest {
   @Autowired
   private ConfigurationService configurationService;
 
-  static Stream<Arguments> provideAddressConfigData() {
+  static Stream<Arguments> testGetAddressConfigArgs() {
     return Stream.of(
-      Arguments.of("1947e709-8d60-42e2-8dde-7566ae446d24", "Address 123"), // existing config
-      Arguments.of(null, ""), // null config ID
-      Arguments.of("116a38c2-cac3-4f08-816b-afebfebe453d", ""), // non-existing config
-      Arguments.of("8ea92aa2-7b11-4f0e-9ed2-ab8fe281f37f", "") // config without address value
+      Arguments.of(null, ""), // No config id
+      Arguments.of("1947e709-8d60-42e2-8dde-7566ae446d24", "Address 123"), // Config with address
+      Arguments.of("8ea92aa2-7b11-4f0e-9ed2-ab8fe281f37f", ""), // Config without address
+      Arguments.of("116a38c2-cac3-4f08-816b-afebfebe453d", ""), // Config without a body
+      Arguments.of("c5cefe49-e4d4-433e-b286-24ffd935b043", "")  // No config
     );
   }
 
   @ParameterizedTest
-  @MethodSource("provideAddressConfigData")
+  @MethodSource("testGetAddressConfigArgs")
   void testGetAddressConfig(String addressConfigId, String expectedAddress) {
-    UUID configId = addressConfigId != null ? UUID.fromString(addressConfigId) : null;
-    String address = configurationService.getAddressConfig(configId);
-    assertEquals(expectedAddress, address);
+    var configId = addressConfigId != null ? UUID.fromString(addressConfigId) : null;
+    assertEquals(expectedAddress, configurationService.getAddressConfig(configId));
   }
 }

--- a/src/test/resources/mappings/configurations.json
+++ b/src/test/resources/mappings/configurations.json
@@ -42,6 +42,19 @@
     {
       "request": {
         "method": "GET",
+        "url": "/configurations/entries/c5cefe49-e4d4-433e-b286-24ffd935b043"
+      },
+      "response": {
+        "status": 404,
+        "body": "{}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
         "url": "/configurations/entries/8ea92aa2-7b11-4f0e-9ed2-ab8fe281f37f"
       },
       "response": {


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODEXPW-566>

## Approach

- Handle config not found exception when the `shipTo` cannot be populated (i.e. make `shipTo` optional)
- Fix Spring Batch conditional flow to allow Export History step to run after the FTP step
- Test manually using both ORDERING (FTP) and CLAIMS (CSV & FTP) export types via Telepresence (edev)