### PR TITLE
[MODORDERS-1269] Removed alerts, reporting codes, CompositePoLine

### DIFF
--- a/src/main/java/org/folio/dew/batch/acquisitions/config/AcquisitionExportConfig.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/config/AcquisitionExportConfig.java
@@ -3,7 +3,7 @@ package org.folio.dew.batch.acquisitions.config;
 import org.folio.dew.batch.acquisitions.mapper.CsvMapper;
 import org.folio.dew.batch.acquisitions.mapper.ExportResourceMapper;
 import org.folio.dew.batch.acquisitions.mapper.converter.CompOrderEdiConverter;
-import org.folio.dew.batch.acquisitions.mapper.converter.CompPoLineEdiConverter;
+import org.folio.dew.batch.acquisitions.mapper.converter.PoLineEdiConverter;
 import org.folio.dew.batch.acquisitions.mapper.EdifactMapper;
 import org.folio.dew.batch.acquisitions.services.ConfigurationService;
 import org.folio.dew.batch.acquisitions.services.ExpenseClassService;
@@ -21,14 +21,14 @@ import org.springframework.context.annotation.Configuration;
 public class AcquisitionExportConfig {
 
   @Bean
-  CompPoLineEdiConverter compositePOLineConverter(IdentifierTypeService identifierTypeService, MaterialTypeService materialTypeService,
-                                                  ExpenseClassService expenseClassService, LocationService locationService, HoldingService holdingService) {
-    return new CompPoLineEdiConverter(identifierTypeService, materialTypeService, expenseClassService, locationService, holdingService);
+  PoLineEdiConverter poLineConverter(IdentifierTypeService identifierTypeService, MaterialTypeService materialTypeService,
+                                     ExpenseClassService expenseClassService, LocationService locationService, HoldingService holdingService) {
+    return new PoLineEdiConverter(identifierTypeService, materialTypeService, expenseClassService, locationService, holdingService);
   }
 
   @Bean
-  CompOrderEdiConverter compositePurchaseOrderConverter(CompPoLineEdiConverter compPoLineEdiConverter, ConfigurationService configurationService) {
-    return new CompOrderEdiConverter(compPoLineEdiConverter, configurationService);
+  CompOrderEdiConverter compositePurchaseOrderConverter(PoLineEdiConverter poLineEdiConverter, ConfigurationService configurationService) {
+    return new CompOrderEdiConverter(poLineEdiConverter, configurationService);
   }
 
   @Bean

--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/MapToEdifactClaimsTasklet.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/MapToEdifactClaimsTasklet.java
@@ -84,10 +84,10 @@ public class MapToEdifactClaimsTasklet extends MapToEdifactTasklet {
       .filter(CollectionUtils::isNotEmpty)
       .map(orders -> {
         var poLines = orders.stream()
-          .map(CompositePurchaseOrder::getCompositePoLines)
+          .map(CompositePurchaseOrder::getPoLines)
           .flatMap(Collection::stream)
           .toList();
-        return orders.get(0).compositePoLines(poLines);
+        return orders.get(0).poLines(poLines);
       }).toList();
 
     return new ExportHolder(compOrders, pieces);

--- a/src/main/java/org/folio/dew/batch/acquisitions/mapper/CsvMapper.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/mapper/CsvMapper.java
@@ -12,9 +12,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.dew.batch.acquisitions.mapper.converter.ClaimCsvConverter;
 import org.folio.dew.batch.acquisitions.services.OrdersService;
-import org.folio.dew.domain.dto.CompositePoLine;
 import org.folio.dew.domain.dto.CompositePurchaseOrder;
 import org.folio.dew.domain.dto.Piece;
+import org.folio.dew.domain.dto.PoLine;
 import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig;
 import org.folio.dew.domain.dto.acquisitions.edifact.ClaimCsvEntry;
 
@@ -41,8 +41,8 @@ public class CsvMapper implements ExportResourceMapper {
     // Map each PoLine ID to its corresponding Pieces
     var poLineIdToPieces = pieces.stream().collect(groupingBy(Piece::getPoLineId));
     // Map each PoLine ID to its corresponding PoLine
-    var poLineIdToPoLine = orders.stream().flatMap(order -> order.getCompositePoLines().stream())
-      .collect(Collectors.toMap(CompositePoLine::getId, Function.identity()));
+    var poLineIdToPoLine = orders.stream().flatMap(order -> order.getPoLines().stream())
+      .collect(Collectors.toMap(PoLine::getId, Function.identity()));
     // Map each Piece ID to its corresponding Title
     var pieceIdToTitle = poLineIdToPieces.entrySet().stream()
       .flatMap(entry -> entry.getValue().stream()
@@ -61,11 +61,11 @@ public class CsvMapper implements ExportResourceMapper {
     // Return a list of ClaimCsvEntry objects, each representing a group of claimed pieces
     return claimedPieces.entrySet().stream()
       .map(entry -> entry.getKey().withQuantity(entry.getValue()))
-      .sorted(Comparator.comparing(o -> o.compositePoLine().getPoLineNumber()))
+      .sorted(Comparator.comparing(o -> o.poLine().getPoLineNumber()))
       .toList();
   }
 
-  private String getTitleById(CompositePoLine poLine, Piece piece) {
+  private String getTitleById(PoLine poLine, Piece piece) {
     return Boolean.TRUE.equals(poLine.getIsPackage())
       ? ordersService.getTitleById(piece.getTitleId()).getTitle()
       : poLine.getTitleOrPackage();

--- a/src/main/java/org/folio/dew/batch/acquisitions/mapper/converter/ClaimCsvFields.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/mapper/converter/ClaimCsvFields.java
@@ -14,9 +14,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ClaimCsvFields implements ExtractableField<ClaimCsvEntry, String> {
 
-  POL_NUMBER("POL number", entry -> entry.compositePoLine().getPoLineNumber()),
-  ORDER_NUMBER("Vendor order number", entry -> getVendorOrderNumber(entry.compositePoLine())),
-  ACCOUNT_NUMBER("Account number", entry -> getVendorAccountNumber(entry.compositePoLine())),
+  POL_NUMBER("POL number", entry -> entry.poLine().getPoLineNumber()),
+  ORDER_NUMBER("Vendor order number", entry -> getVendorOrderNumber(entry.poLine())),
+  ACCOUNT_NUMBER("Account number", entry -> getVendorAccountNumber(entry.poLine())),
   EXPECTED_DATE("Expected date", entry -> getFormattedDate(entry.piece().getReceiptDate())),
   TITLE("Title from piece", ClaimCsvEntry::title),
   DISPLAY_SUMMARY("Display summary", entry -> entry.piece().getDisplaySummary()),

--- a/src/main/java/org/folio/dew/batch/acquisitions/mapper/converter/PoLineEdiConverter.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/mapper/converter/PoLineEdiConverter.java
@@ -18,12 +18,12 @@ import org.folio.dew.batch.acquisitions.services.HoldingService;
 import org.folio.dew.batch.acquisitions.services.IdentifierTypeService;
 import org.folio.dew.batch.acquisitions.services.LocationService;
 import org.folio.dew.batch.acquisitions.services.MaterialTypeService;
-import org.folio.dew.domain.dto.CompositePoLine;
 import org.folio.dew.domain.dto.Contributor;
 import org.folio.dew.domain.dto.Cost;
 import org.folio.dew.domain.dto.FundDistribution;
 import org.folio.dew.domain.dto.Location;
 import org.folio.dew.domain.dto.Piece;
+import org.folio.dew.domain.dto.PoLine;
 import org.folio.dew.domain.dto.ProductIdentifier;
 import org.folio.dew.domain.dto.ReferenceNumberItem;
 import org.javamoney.moneta.Money;
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CompPoLineEdiConverter {
+public class PoLineEdiConverter {
   private static final int MAX_CHARS_PER_LINE = 70;
   private static final int MAX_NUMBER_OF_REFS = 10;
   private static final String PRODUCT_ID_FUNCTION_CODE_MAIN_PRODUCT_IDNTIFICATION = "5";
@@ -56,7 +56,7 @@ public class CompPoLineEdiConverter {
   private final LocationService locationService;
   private final HoldingService holdingService;
 
-  public CompPoLineEdiConverter(IdentifierTypeService identifierTypeService, MaterialTypeService materialTypeService,
+  public PoLineEdiConverter(IdentifierTypeService identifierTypeService, MaterialTypeService materialTypeService,
                                 ExpenseClassService expenseClassService, LocationService locationService, HoldingService holdingService) {
     this.identifierTypeService = identifierTypeService;
     this.materialTypeService = materialTypeService;
@@ -65,7 +65,7 @@ public class CompPoLineEdiConverter {
     this.holdingService = holdingService;
   }
 
-  public int convertPOLine(CompositePoLine poLine, List<Piece> pieces, EDIStreamWriter writer, int currentLineNumber, int quantityOrdered) throws EDIStreamException {
+  public int convertPOLine(PoLine poLine, List<Piece> pieces, EDIStreamWriter writer, int currentLineNumber, int quantityOrdered) throws EDIStreamException {
     int messageSegmentCount = 0;
 
     Map<String, ProductIdentifier> productTypeProductIdentifierMap = new HashMap<>();
@@ -352,7 +352,7 @@ public class CompPoLineEdiConverter {
       .writeEndSegment();
   }
 
-  private void writePoLineCurrency(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writePoLineCurrency(PoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("CUX")
       .writeStartElement()
       .writeComponent("2")
@@ -377,7 +377,7 @@ public class CompPoLineEdiConverter {
       .writeEndSegment();
   }
 
-  private void writePOLineNumber(CompositePoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
+  private void writePOLineNumber(PoLine poLine, EDIStreamWriter writer) throws EDIStreamException {
     writer.writeStartSegment("RFF")
       .writeStartElement()
       .writeComponent("LI")
@@ -424,7 +424,7 @@ public class CompPoLineEdiConverter {
       .writeEndSegment();
   }
 
-  private List<ProductIdentifier> getProductIds(CompositePoLine poLine) {
+  private List<ProductIdentifier> getProductIds(PoLine poLine) {
     if (poLine.getDetails() != null && poLine.getDetails().getProductIds() != null) {
       return poLine.getDetails().getProductIds();
     } else {
@@ -452,7 +452,7 @@ public class CompPoLineEdiConverter {
     }
   }
 
-  private List<Contributor> getContributors(CompositePoLine poLine) {
+  private List<Contributor> getContributors(PoLine poLine) {
     if (poLine.getContributors() != null) {
       return poLine.getContributors();
     } else {
@@ -460,7 +460,7 @@ public class CompPoLineEdiConverter {
     }
   }
 
-  private String[] getTitleParts(CompositePoLine poLine) {
+  private String[] getTitleParts(PoLine poLine) {
     String title = poLine.getTitleOrPackage();
     return title.split("(?<=\\G.{" + MAX_CHARS_PER_LINE + "})");
   }
@@ -471,7 +471,7 @@ public class CompPoLineEdiConverter {
       .joining(":");
   }
 
-  private String getPhysicalMaterial(CompositePoLine poLine) {
+  private String getPhysicalMaterial(PoLine poLine) {
     if (poLine.getPhysical() != null && poLine.getPhysical().getMaterialType() != null) {
       String materialTypeId = poLine.getPhysical().getMaterialType();
       return materialTypeService.getMaterialTypeName(materialTypeId);
@@ -479,7 +479,7 @@ public class CompPoLineEdiConverter {
     return "";
   }
 
-  private String getElectronicMaterial(CompositePoLine poLine) {
+  private String getElectronicMaterial(PoLine poLine) {
      if (poLine.getEresource() != null && poLine.getEresource().getMaterialType() != null) {
       String materialTypeId = poLine.getEresource().getMaterialType();
       return materialTypeService.getMaterialTypeName(materialTypeId);
@@ -487,7 +487,7 @@ public class CompPoLineEdiConverter {
     return "";
   }
 
-  private List<FundDistribution> getFundDistribution(CompositePoLine poLine) {
+  private List<FundDistribution> getFundDistribution(PoLine poLine) {
     if (poLine.getFundDistribution() != null) {
       return poLine.getFundDistribution();
     }
@@ -517,7 +517,7 @@ public class CompPoLineEdiConverter {
     return vendorOrderNumber;
   }
 
-  private List<Location> getLocations(CompositePoLine poLine) {
+  private List<Location> getLocations(PoLine poLine) {
     if (poLine.getLocations() != null) {
       return poLine.getLocations();
     }

--- a/src/main/java/org/folio/dew/batch/acquisitions/services/ExportHistoryService.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/services/ExportHistoryService.java
@@ -8,9 +8,9 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.dew.config.kafka.KafkaService;
-import org.folio.dew.domain.dto.CompositePoLine;
 import org.folio.dew.domain.dto.ExportHistory;
 import org.folio.dew.domain.dto.ExportType;
+import org.folio.dew.domain.dto.PoLine;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,16 +19,16 @@ import org.springframework.stereotype.Service;
 public class ExportHistoryService {
   private final KafkaService kafkaService;
 
-  void sendExportHistoryEvent(Set<CompositePoLine> compositePoLines, String jobId) {
-    var exportHistory = buildExportHistoryRecord(compositePoLines, jobId);
+  void sendExportHistoryEvent(Set<PoLine> poLines, String jobId) {
+    var exportHistory = buildExportHistoryRecord(poLines, jobId);
     var id = UUID.randomUUID().toString();
 
     kafkaService.send(KafkaService.Topic.EXPORT_HISTORY_CREATE, id, exportHistory);
   }
 
-  private ExportHistory buildExportHistoryRecord(Set<CompositePoLine> compositePoLines, String jobId) {
+  private ExportHistory buildExportHistoryRecord(Set<PoLine> poLines, String jobId) {
     ExportHistory eh = new ExportHistory();
-    var poLineIds = compositePoLines.stream().map(CompositePoLine::getId).collect(Collectors.toList());
+    var poLineIds = poLines.stream().map(PoLine::getId).collect(Collectors.toList());
     eh.id(UUID.randomUUID().toString());
     // TODO: check TIME ZONE
     eh.exportDate(Date.from(Instant.now()));

--- a/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
@@ -15,8 +15,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
-import org.folio.dew.domain.dto.CompositePoLine;
 import org.folio.dew.domain.dto.ExportType;
+import org.folio.dew.domain.dto.PoLine;
 import org.folio.dew.domain.dto.ReferenceNumberItem;
 import org.folio.dew.domain.dto.VendorDetail;
 import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig;
@@ -28,7 +28,7 @@ public class ExportUtils {
 
   private ExportUtils() { }
 
-  public static List<ReferenceNumberItem> getVendorReferenceNumbers(CompositePoLine poLine) {
+  public static List<ReferenceNumberItem> getVendorReferenceNumbers(PoLine poLine) {
     return Optional.ofNullable(poLine.getVendorDetail())
       .map(VendorDetail::getReferenceNumbers)
       .orElse(new ArrayList<>());
@@ -41,13 +41,13 @@ public class ExportUtils {
       .orElse(null);
   }
 
-  public static String getVendorOrderNumber(CompositePoLine poLine) {
+  public static String getVendorOrderNumber(PoLine poLine) {
     return Optional.ofNullable(getVendorOrderNumber(getVendorReferenceNumbers(poLine)))
       .map(ReferenceNumberItem::getRefNumber)
       .orElse(null);
   }
 
-  public static String getVendorAccountNumber(CompositePoLine poLine) {
+  public static String getVendorAccountNumber(PoLine poLine) {
     return Optional.ofNullable(poLine.getVendorDetail())
       .map(VendorDetail::getVendorAccount)
       .orElse(null);

--- a/src/main/java/org/folio/dew/domain/dto/acquisitions/edifact/ClaimCsvEntry.java
+++ b/src/main/java/org/folio/dew/domain/dto/acquisitions/edifact/ClaimCsvEntry.java
@@ -2,13 +2,13 @@ package org.folio.dew.domain.dto.acquisitions.edifact;
 
 import java.util.Objects;
 
-import org.folio.dew.domain.dto.CompositePoLine;
 import org.folio.dew.domain.dto.Piece;
+import org.folio.dew.domain.dto.PoLine;
 
-public record ClaimCsvEntry(CompositePoLine compositePoLine, Piece piece, String title, long quantity) {
+public record ClaimCsvEntry(PoLine poLine, Piece piece, String title, long quantity) {
 
   public ClaimCsvEntry withQuantity(long quantity) {
-    return new ClaimCsvEntry(compositePoLine, piece, title, quantity);
+    return new ClaimCsvEntry(poLine, piece, title, quantity);
   }
 
   @Override
@@ -16,7 +16,7 @@ public record ClaimCsvEntry(CompositePoLine compositePoLine, Piece piece, String
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ClaimCsvEntry that = (ClaimCsvEntry) o;
-    return Objects.equals(compositePoLine.getPoLineNumber(), that.compositePoLine.getPoLineNumber())
+    return Objects.equals(poLine.getPoLineNumber(), that.poLine.getPoLineNumber())
       && Objects.equals(piece.getDisplaySummary(), that.piece.getDisplaySummary())
       && Objects.equals(piece.getChronology(), that.piece.getChronology())
       && Objects.equals(piece.getEnumeration(), that.piece.getEnumeration())
@@ -25,7 +25,7 @@ public record ClaimCsvEntry(CompositePoLine compositePoLine, Piece piece, String
 
   @Override
   public int hashCode() {
-    return Objects.hash(compositePoLine.getPoLineNumber(), piece.getDisplaySummary(), piece.getChronology(), piece.getEnumeration(), title);
+    return Objects.hash(poLine.getPoLineNumber(), piece.getDisplaySummary(), piece.getChronology(), piece.getEnumeration(), title);
   }
 
 }

--- a/src/main/resources/swagger.api/order-export.yaml
+++ b/src/main/resources/swagger.api/order-export.yaml
@@ -17,12 +17,8 @@ components:
       format: uuid
     referenceNumberItem:
       $ref: '../../../../folio-export-common/schemas/acquisitions/common/reference_number_item.json#/ReferenceNumberItem'
-    compositePoLine:
-      $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders/composite_po_line.json#/CompositePoLine'
     compositePurchaseOrder:
       $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders/composite_purchase_order.json#/CompositePurchaseOrder'
-    alert:
-      $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders-storage/alert.json#/Alert'
     claim:
       $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders-storage/claim.json#/Claim'
     closeReason:
@@ -47,8 +43,6 @@ components:
       $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders-storage/physical.json#/Physical'
     productIdentifier:
       $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders-storage/product_identifier.json#/ProductIdentifier'
-    reportingCode:
-      $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders-storage/reporting_code.json#/ReportingCode'
     vendorDetail:
       $ref: '../../../../folio-export-common/schemas/acquisitions/mod-orders-storage/vendor_detail.json#/VendorDetail'
     exportHistory:

--- a/src/test/java/org/folio/dew/batch/acquisitions/mapper/EdifactMapperTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/mapper/EdifactMapperTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import lombok.extern.log4j.Log4j2;
 
 import org.folio.dew.batch.acquisitions.mapper.converter.CompOrderEdiConverter;
-import org.folio.dew.batch.acquisitions.mapper.converter.CompPoLineEdiConverter;
+import org.folio.dew.batch.acquisitions.mapper.converter.PoLineEdiConverter;
 import org.folio.dew.batch.acquisitions.services.ConfigurationService;
 import org.folio.dew.batch.acquisitions.services.ExpenseClassService;
 import org.folio.dew.batch.acquisitions.services.HoldingService;
@@ -68,8 +68,8 @@ class EdifactMapperTest {
 
   @BeforeEach
   void setUp() {
-    var compositePOLineConverter = new CompPoLineEdiConverter(identifierTypeService, materialTypeService, expenseClassService, locationService, holdingService);
-    var compositePOConverter = new CompOrderEdiConverter(compositePOLineConverter, configurationService);
+    var poLineConverter = new PoLineEdiConverter(identifierTypeService, materialTypeService, expenseClassService, locationService, holdingService);
+    var compositePOConverter = new CompOrderEdiConverter(poLineConverter, configurationService);
     edifactMapper = new EdifactMapper(compositePOConverter);
     objectMapper = new JacksonConfiguration().objectMapper();
 

--- a/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
+++ b/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
@@ -2,8 +2,8 @@ package org.folio.dew.utils;
 
 import org.folio.dew.CopilotGenerated;
 import org.folio.dew.batch.acquisitions.utils.ExportUtils;
-import org.folio.dew.domain.dto.CompositePoLine;
 import org.folio.dew.domain.dto.ExportType;
+import org.folio.dew.domain.dto.PoLine;
 import org.folio.dew.domain.dto.ReferenceNumberItem;
 import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig;
 import org.junit.jupiter.api.Test;
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class ExportUtilsTest {
   @Test
   void getVendorReferenceNumbersReturnsEmptyListWhenVendorDetailIsNull() {
-    CompositePoLine poLine = new CompositePoLine();
+    PoLine poLine = new PoLine();
     assertThat(ExportUtils.getVendorReferenceNumbers(poLine), is(List.of()));
   }
 
@@ -46,7 +46,7 @@ public class ExportUtilsTest {
 
   @Test
   void getVendorAccountNumberReturnsNullWhenVendorDetailIsNull() {
-    CompositePoLine poLine = new CompositePoLine();
+    PoLine poLine = new PoLine();
     assertThat(ExportUtils.getVendorAccountNumber(poLine), is(nullValue()));
   }
 

--- a/src/test/resources/edifact/acquisitions/composite_purchase_order.json
+++ b/src/test/resources/edifact/acquisitions/composite_purchase_order.json
@@ -11,7 +11,7 @@
   "totalItems": 1,
   "vendor": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Open",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "f7cebba9-900d-4e46-ac96-9dfdb6da214e",
       "edition": "",
@@ -19,7 +19,6 @@
       "instanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
       "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
       "automaticExport": true,
-      "alerts": [],
       "claims": [],
       "collection": false,
       "contributors": [
@@ -79,7 +78,6 @@
       "publisher": "Palgrave Macmillan",
       "purchaseOrderId": "91103993-acc5-46c4-a2e6-a79cae1959be",
       "receiptStatus": "Pending",
-      "reportingCodes": [],
       "rush": false,
       "source": "User",
       "titleOrPackage": "Futures, biometrics and neuroscience research Luiz Moutinho, Mladen Sokele, editors",

--- a/src/test/resources/edifact/acquisitions/comprehensive_composite_purchase_order.json
+++ b/src/test/resources/edifact/acquisitions/comprehensive_composite_purchase_order.json
@@ -17,7 +17,7 @@
   "totalItems": 4,
   "vendor": "50fb6ae0-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "81b6503d-1f50-404d-a663-794b7f726ffd",
       "edition": "",
@@ -25,7 +25,6 @@
       "instanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
       "acquisitionMethod": "2ee31dec-4dab-4807-938c-b4d35b72f523",
       "automaticExport": false,
-      "alerts": [],
       "claims": [],
       "collection": false,
       "contributors": [
@@ -140,7 +139,6 @@
       "publisher": "Palgrave Macmillan",
       "purchaseOrderId": "96aec519-e756-4a39-87f2-76a61ea878a1",
       "receiptStatus": "Pending",
-      "reportingCodes": [],
       "rush": false,
       "source": "User",
       "titleOrPackage": "Futures, biometrics and neuroscience research Luiz Moutinho, Mladen Sokele, editors",
@@ -168,7 +166,6 @@
       "instanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
       "acquisitionMethod": "2ee31dec-4dab-4807-938c-b4d35b72f523",
       "automaticExport": false,
-      "alerts": [],
       "cancellationRestriction": true,
       "claims": [],
       "collection": false,
@@ -244,7 +241,6 @@
       "publisher": "Otá Records, ",
       "purchaseOrderId": "96aec519-e756-4a39-87f2-76a61ea878a1",
       "receiptStatus": "Pending",
-      "reportingCodes": [],
       "rush": true,
       "source": "User",
       "titleOrPackage": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",

--- a/src/test/resources/edifact/acquisitions/minimalistic_composite_purchase_order.json
+++ b/src/test/resources/edifact/acquisitions/minimalistic_composite_purchase_order.json
@@ -1,7 +1,7 @@
 {
   "id": "24fa8e44-ae40-4eca-86c3-c4838420ce1f",
   "poNumber": "10002",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "31af5b5c-251e-4582-9896-2c9cef360284",
       "poLineNumber": "10002-1",

--- a/src/test/resources/edifact/acquisitions/po_line_collection.json
+++ b/src/test/resources/edifact/acquisitions/po_line_collection.json
@@ -7,7 +7,6 @@
       "instanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
       "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
       "automaticExport": true,
-      "alerts": [],
       "claims": [],
       "collection": false,
       "contributors": [
@@ -67,7 +66,6 @@
       "publisher": "Palgrave Macmillan",
       "purchaseOrderId": "91103993-acc5-46c4-a2e6-a79cae1959be",
       "receiptStatus": "Pending",
-      "reportingCodes": [],
       "rush": false,
       "source": "User",
       "titleOrPackage": "Futures, biometrics and neuroscience research Luiz Moutinho, Mladen Sokele, editors",

--- a/src/test/resources/edifact/acquisitions/purchase_order_empty_vendor_account.json
+++ b/src/test/resources/edifact/acquisitions/purchase_order_empty_vendor_account.json
@@ -1,7 +1,7 @@
 {
   "id": "24fa8e44-ae40-4eca-86c3-c4838420ce1f",
   "poNumber": "10003",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "31af5b5c-251e-4582-9896-2c9cef360288",
       "poLineNumber": "10003-1",

--- a/src/test/resources/edifact/acquisitions/purchase_order_non_ean_product_ids.json
+++ b/src/test/resources/edifact/acquisitions/purchase_order_non_ean_product_ids.json
@@ -1,7 +1,7 @@
 {
   "id": "77fa8e44-ae40-4eca-86c3-c4838420ce1f",
   "poNumber": "10004",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "55af5b5c-251e-4582-9896-2c9cef360284",
       "poLineNumber": "10004-1",

--- a/src/test/resources/edifact/acquisitions/purchase_order_title_with_escape_chars.json
+++ b/src/test/resources/edifact/acquisitions/purchase_order_title_with_escape_chars.json
@@ -1,7 +1,7 @@
 {
   "id": "24fa8e44-ae40-4eca-86c3-c483bf20ce1f",
   "poNumber": "10005",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "31af5b5c-251e-4582-9896-2c9cef360288",
       "poLineNumber": "10005-1",


### PR DESCRIPTION
## Purpose
[MODORDERS-1269](https://folio-org.atlassian.net/browse/MODORDERS-1269) - Remove alerts and reporting codes from order lines, use a single order line schema

## Approach
- Removed alerts and reporting codes
- Use a single po line schema, no more "composite po line"

## Related PRs
- See [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/477)
- Required for compilation: folio-export-common

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] Check logging
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
