### PR TITLE
[MODEXPW-584-6]. Restrict file format prefix only for Claiming

### DIFF
--- a/src/main/java/org/folio/dew/batch/acquisitions/jobs/MapToEdifactTasklet.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/jobs/MapToEdifactTasklet.java
@@ -118,8 +118,9 @@ public abstract class MapToEdifactTasklet implements Tasklet {
   private String getFileName(VendorEdiOrdersExportConfig ediExportConfig) {
     var vendorName = organizationsService.getOrganizationById(ediExportConfig.getVendorId().toString()).get("code").asText();
     var configName = ediExportConfig.getConfigName();
+    var integrationType = ediExportConfig.getIntegrationType();
     var fileFormat = ediExportConfig.getFileFormat();
-    return generateFileName(vendorName, configName, fileFormat);
+    return generateFileName(vendorName, configName, integrationType, fileFormat);
   }
 
   private <T> T convertTo(Object value, Class<T> c) {

--- a/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
@@ -3,6 +3,7 @@ package org.folio.dew.batch.acquisitions.utils;
 import static org.folio.dew.batch.acquisitions.utils.ExportConfigFields.FTP_PORT;
 import static org.folio.dew.batch.acquisitions.utils.ExportConfigFields.SERVER_ADDRESS;
 import static org.folio.dew.domain.dto.ReferenceNumberItem.RefNumberTypeEnum.ORDER_REFERENCE_NUMBER;
+import static org.folio.dew.domain.dto.VendorEdiOrdersExportConfig.IntegrationTypeEnum.CLAIMING;
 import static org.folio.dew.domain.dto.VendorEdiOrdersExportConfig.IntegrationTypeEnum.ORDERING;
 import static org.folio.dew.domain.dto.VendorEdiOrdersExportConfig.TransmissionMethodEnum.FTP;
 
@@ -24,7 +25,8 @@ import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig.FileFormatEnum;
 
 public class ExportUtils {
 
-  private static final String FILE_NAME_FORMAT = "edi.%s_%s_%s.%s";
+  private static final String DEFAULT_FILE_NAME_FORMAT = "%s_%s_%s.%s";
+  private static final String CLAIMING_EDI_FILE_NAME_FORMAT = "edi.%s_%s_%s.%s";
 
   private ExportUtils() { }
 
@@ -71,11 +73,17 @@ public class ExportUtils {
     }
   }
 
-  public static String generateFileName(String vendorName, String configName, FileFormatEnum fileFormat) {
-    return FILE_NAME_FORMAT.formatted(vendorName,
-      configName,
-      new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date()),
-      fileFormat.getValue().toLowerCase()); // Enum being EDI or CSV
+  public static String generateFileName(String vendorName, String configName, VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, FileFormatEnum fileFormat) {
+    var fileNameFormat = getFileNameFormat(integrationType, fileFormat);
+    var timestamp = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+    return fileNameFormat.formatted(vendorName, configName, timestamp, fileFormat.getValue().toLowerCase());
+  }
+
+  private static String getFileNameFormat(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, FileFormatEnum fileFormat) {
+    if (integrationType == CLAIMING && fileFormat == FileFormatEnum.EDI) {
+      return CLAIMING_EDI_FILE_NAME_FORMAT;
+    }
+    return DEFAULT_FILE_NAME_FORMAT;
   }
 
   public static ExportType convertIntegrationTypeToExportType(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType) {

--- a/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
@@ -25,8 +25,7 @@ import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig.FileFormatEnum;
 
 public class ExportUtils {
 
-  private static final String DEFAULT_FILE_NAME_FORMAT = "%s_%s_%s.%s";
-  private static final String CLAIMING_EDI_FILE_NAME_FORMAT = "edi.%s_%s_%s.%s";
+  private static final String FILE_NAME_FORMAT = "%s.%s_%s_%s.%s";
 
   private ExportUtils() { }
 
@@ -74,16 +73,16 @@ public class ExportUtils {
   }
 
   public static String generateFileName(String vendorName, String configName, VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, FileFormatEnum fileFormat) {
-    var fileNameFormat = getFileNameFormat(integrationType, fileFormat);
+    var filePrefix = getFilePrefix(integrationType, fileFormat);
     var timestamp = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
-    return fileNameFormat.formatted(vendorName, configName, timestamp, fileFormat.getValue().toLowerCase());
+    return FILE_NAME_FORMAT.formatted(filePrefix, vendorName, configName, timestamp, fileFormat.getValue().toLowerCase());
   }
 
-  private static String getFileNameFormat(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, FileFormatEnum fileFormat) {
-    if (integrationType == CLAIMING && fileFormat == FileFormatEnum.EDI) {
-      return CLAIMING_EDI_FILE_NAME_FORMAT;
+  public static String getFilePrefix(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, FileFormatEnum fileFormat) {
+    if (integrationType == CLAIMING) {
+      return fileFormat == FileFormatEnum.EDI ? "edi_claims" : "csv_claims";
     }
-    return DEFAULT_FILE_NAME_FORMAT;
+    return "edi_orders";
   }
 
   public static ExportType convertIntegrationTypeToExportType(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType) {

--- a/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/utils/ExportUtils.java
@@ -25,7 +25,7 @@ import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig.FileFormatEnum;
 
 public class ExportUtils {
 
-  private static final String FILE_NAME_FORMAT = "%s.%s_%s_%s.%s";
+  private static final String FILE_NAME_FORMAT = "%s_%s_%s_%s.%s";
 
   private ExportUtils() { }
 

--- a/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
+++ b/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
@@ -7,6 +7,8 @@ import org.folio.dew.domain.dto.PoLine;
 import org.folio.dew.domain.dto.ReferenceNumberItem;
 import org.folio.dew.domain.dto.VendorEdiOrdersExportConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Date;
 import java.util.List;
@@ -60,13 +62,22 @@ public class ExportUtilsTest {
     assertThat(ExportUtils.getFormattedDate(null), is(""));
   }
 
-  @Test
-  void generateFileNameGeneratesCorrectFileName() {
-    String vendorName = "vendor";
-    String configName = "config";
-    VendorEdiOrdersExportConfig.FileFormatEnum fileFormat = VendorEdiOrdersExportConfig.FileFormatEnum.EDI;
-    String fileName = ExportUtils.generateFileName(vendorName, configName, fileFormat);
-    assertThat(fileName.matches("^edi.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$"), is(true));
+  @ParameterizedTest
+  @CsvSource({"ORDERING,EDI", "CLAIMING,EDI", "CLAIMING,CSV"})
+  void generateFileNameGeneratesCorrectFileName(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, VendorEdiOrdersExportConfig.FileFormatEnum fileFormat) {
+    var fileName = ExportUtils.generateFileName("vendor", "config", integrationType, fileFormat);
+    assertThat(fileName.matches(getRegexPattern(integrationType, fileFormat)), is(true));
+  }
+
+  private String getRegexPattern(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, VendorEdiOrdersExportConfig.FileFormatEnum fileFormat) {
+    if (integrationType == VendorEdiOrdersExportConfig.IntegrationTypeEnum.CLAIMING) {
+      if (fileFormat == VendorEdiOrdersExportConfig.FileFormatEnum.EDI) {
+        return "^edi.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
+      } else {
+        return "^vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.csv$";
+      }
+    }
+    return  "^vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
   }
 
   @Test

--- a/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
+++ b/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
@@ -66,18 +66,19 @@ public class ExportUtilsTest {
   @CsvSource({"ORDERING,EDI", "CLAIMING,EDI", "CLAIMING,CSV"})
   void generateFileNameGeneratesCorrectFileName(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, VendorEdiOrdersExportConfig.FileFormatEnum fileFormat) {
     var fileName = ExportUtils.generateFileName("vendor", "config", integrationType, fileFormat);
+    System.out.println(fileName);
     assertThat(fileName.matches(getRegexPattern(integrationType, fileFormat)), is(true));
   }
 
   private String getRegexPattern(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, VendorEdiOrdersExportConfig.FileFormatEnum fileFormat) {
     if (integrationType == VendorEdiOrdersExportConfig.IntegrationTypeEnum.CLAIMING) {
       if (fileFormat == VendorEdiOrdersExportConfig.FileFormatEnum.EDI) {
-        return "^edi.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
+        return "^edi_claims.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
       } else {
-        return "^vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.csv$";
+        return "^csv_claims.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.csv$";
       }
     }
-    return  "^vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
+    return  "^edi_orders.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
   }
 
   @Test

--- a/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
+++ b/src/test/java/org/folio/dew/utils/ExportUtilsTest.java
@@ -73,12 +73,12 @@ public class ExportUtilsTest {
   private String getRegexPattern(VendorEdiOrdersExportConfig.IntegrationTypeEnum integrationType, VendorEdiOrdersExportConfig.FileFormatEnum fileFormat) {
     if (integrationType == VendorEdiOrdersExportConfig.IntegrationTypeEnum.CLAIMING) {
       if (fileFormat == VendorEdiOrdersExportConfig.FileFormatEnum.EDI) {
-        return "^edi_claims.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
+        return "^edi_claims_vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
       } else {
-        return "^csv_claims.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.csv$";
+        return "^csv_claims_vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.csv$";
       }
     }
-    return  "^edi_orders.vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
+    return  "^edi_orders_vendor_config_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.edi$";
   }
 
   @Test


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODEXPW-584>

## Approach

- Restrict `edi.` file format prefix only for Claiming if the integration type is set to EDI