### PR TITLE
MODEXPW-588. Move acquisition dependencies to optional

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -51,10 +51,6 @@
       "version": "2.0"
     },
     {
-      "id": "finance-storage.expense-classes",
-      "version": "3.0"
-    },
-    {
       "id": "holdings-note-types",
       "version": "1.0"
     },
@@ -96,30 +92,6 @@
     },
     {
       "id": "notes",
-      "version": "4.0"
-    },
-    {
-      "id": "orders-storage.purchase-orders",
-      "version": "8.0"
-    },
-    {
-      "id": "orders-storage.po-lines",
-      "version": "13.0"
-    },
-    {
-      "id": "orders-storage.pieces",
-      "version": "5.0"
-    },
-    {
-      "id": "organizations-storage.organizations",
-      "version": "3.3"
-    },
-    {
-      "id": "organizations.organizations",
-      "version": "1.2"
-    },
-    {
-      "id": "order-lines",
       "version": "4.0"
     },
     {
@@ -219,6 +191,34 @@
     {
       "id": "okapi",
       "version": "1.9"
+    },
+    {
+      "id": "orders-storage.purchase-orders",
+      "version": "8.0"
+    },
+    {
+      "id": "order-lines",
+      "version": "4.0"
+    },
+    {
+      "id": "orders-storage.po-lines",
+      "version": "13.0"
+    },
+    {
+      "id": "orders-storage.pieces",
+      "version": "5.0"
+    },
+    {
+      "id": "organizations-storage.organizations",
+      "version": "3.3"
+    },
+    {
+      "id": "organizations.organizations",
+      "version": "1.2"
+    },
+    {
+      "id": "finance-storage.expense-classes",
+      "version": "3.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODEXPW-588

Regarding the remaining issue with app-acquisitions, I believe these acquisition modules should be optional in mod-data-export-worker (and other interfaces related to specific entity types). This is because the module handles export not only for acquisitions data but also for circulation, bursar, bulk edit-related data, and other types. Therefore, if app-acquisitions is not enabled for the library, mod-data-export-worker should still function and handle other export types.

A similar methodology is used in mod-consortia-keycloak, as this module can share dozens of different entity types. All these entity types are declared as optional since the module needs to continue sharing other enabled entity types in the environment:

[GitHub Reference](https://github.com/folio-org/mod-consortia-keycloak/blob/master/descriptors/ModuleDescriptor-template.json#L62)

Before making these modules optional in mod-data-export-worker, we need to ensure that acquisition-related endpoints are not used in the module's startup logic or enabling logic. This will confirm that the module can start without them.