### PR TITLE
[MODEXPW-604] [Bursar] Cleanup exception usage, logging

### DIFF
--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/AccountFilterer.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/AccountFilterer.java
@@ -7,7 +7,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.dew.batch.bursarfeesfines.service.BursarFilterEvaluator;
 import org.folio.dew.domain.dto.BursarExportJob;
 import org.folio.dew.domain.dto.bursarfeesfines.AccountWithAncillaryData;
-import org.folio.dew.error.BursarNoMatchedAccountsException;
+import org.folio.dew.error.BursarNoAccountsToTransferException;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.annotation.AfterStep;
@@ -42,7 +42,7 @@ public class AccountFilterer implements ItemProcessor<AccountWithAncillaryData, 
     if (filteredAccounts.isEmpty()) {
       log.error("No accounts matched the criteria");
       stepExecution.setExitStatus(ExitStatus.FAILED);
-      stepExecution.addFailureException(log.throwing(new BursarNoMatchedAccountsException()));
+      stepExecution.addFailureException(log.throwing(new BursarNoAccountsToTransferException()));
     }
     stepExecution.getJobExecution()
       .getExecutionContext()

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/AccountReader.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/AccountReader.java
@@ -13,7 +13,7 @@ import org.folio.dew.domain.dto.Account;
 import org.folio.dew.domain.dto.Item;
 import org.folio.dew.domain.dto.User;
 import org.folio.dew.domain.dto.bursarfeesfines.AccountWithAncillaryData;
-import org.folio.dew.error.BursarNoAccountsException;
+import org.folio.dew.error.BursarNoAccountsToTransferException;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -61,7 +61,7 @@ public class AccountReader implements ItemReader<AccountWithAncillaryData> {
 
     if (accounts.isEmpty()) {
       log.error("No accounts found, terminating job...");
-      stepExecution.addFailureException(log.throwing(new BursarNoAccountsException()));
+      stepExecution.addFailureException(log.throwing(new BursarNoAccountsToTransferException()));
       return;
     }
 

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/AggregatedAccountFilterer.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/AggregatedAccountFilterer.java
@@ -11,7 +11,7 @@ import org.folio.dew.domain.dto.BursarExportJob;
 import org.folio.dew.domain.dto.Item;
 import org.folio.dew.domain.dto.bursarfeesfines.AccountWithAncillaryData;
 import org.folio.dew.domain.dto.bursarfeesfines.AggregatedAccountsByUser;
-import org.folio.dew.error.BursarNoMatchedAccountsException;
+import org.folio.dew.error.BursarNoAccountsToTransferException;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.annotation.AfterStep;
@@ -57,7 +57,7 @@ public class AggregatedAccountFilterer implements ItemProcessor<AggregatedAccoun
     if (filteredAccounts.isEmpty()) {
       log.error("No accounts matched the aggregate criteria");
       stepExecution.setExitStatus(ExitStatus.FAILED);
-      stepExecution.addFailureException(log.throwing(new BursarNoMatchedAccountsException()));
+      stepExecution.addFailureException(log.throwing(new BursarNoAccountsToTransferException()));
     }
     stepExecution.getJobExecution()
       .getExecutionContext()

--- a/src/main/java/org/folio/dew/error/BursarNoAccountsException.java
+++ b/src/main/java/org/folio/dew/error/BursarNoAccountsException.java
@@ -1,8 +1,0 @@
-package org.folio.dew.error;
-
-public class BursarNoAccountsException extends IllegalStateException {
-
-  public BursarNoAccountsException() {
-    super("No fee/fine accounts were found with a remaining balance.");
-  }
-}

--- a/src/main/java/org/folio/dew/error/BursarNoAccountsToTransferException.java
+++ b/src/main/java/org/folio/dew/error/BursarNoAccountsToTransferException.java
@@ -1,0 +1,8 @@
+package org.folio.dew.error;
+
+public class BursarNoAccountsToTransferException extends IllegalStateException {
+
+  public BursarNoAccountsToTransferException() {
+    super("No fee/fine accounts were found with a remaining balance that matched the provided criteria.");
+  }
+}

--- a/src/main/java/org/folio/dew/error/BursarNoMatchedAccountsException.java
+++ b/src/main/java/org/folio/dew/error/BursarNoMatchedAccountsException.java
@@ -1,8 +1,0 @@
-package org.folio.dew.error;
-
-public class BursarNoMatchedAccountsException extends IllegalStateException {
-
-  public BursarNoMatchedAccountsException() {
-    super("There are fee/fine accounts with a balance, however, all were filtered out by the configured criteria.");
-  }
-}

--- a/src/test/java/org/folio/dew/bursarfeesfines/NoFeeFineMatchingAggregateCriteriaAggregateTest.java
+++ b/src/test/java/org/folio/dew/bursarfeesfines/NoFeeFineMatchingAggregateCriteriaAggregateTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import org.folio.dew.BaseBatchTest;
-import org.folio.dew.error.BursarNoMatchedAccountsException;
+import org.folio.dew.error.BursarNoAccountsToTransferException;
 import org.folio.dew.helpers.bursarfeesfines.BursarFeesFinesTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -148,7 +148,7 @@ class NoFeeFineMatchingAggregateCriteriaAggregateTest extends BaseBatchTest {
     JobExecution jobExecution = testLauncher.launchJob(jobParameters);
 
     assertThat(jobExecution.getExitStatus(), is(ExitStatus.FAILED));
-    assertThat(jobExecution.getAllFailureExceptions(), contains(instanceOf(BursarNoMatchedAccountsException.class)));
+    assertThat(jobExecution.getAllFailureExceptions(), contains(instanceOf(BursarNoAccountsToTransferException.class)));
 
     wireMockServer.verify(getRequestedFor(urlEqualTo(BursarFeesFinesTestUtils.ALL_OPEN_ACCOUNTS_GET_REQUEST)));
 

--- a/src/test/java/org/folio/dew/bursarfeesfines/NoFeeFineMatchingCriteriaTest.java
+++ b/src/test/java/org/folio/dew/bursarfeesfines/NoFeeFineMatchingCriteriaTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import org.folio.dew.BaseBatchTest;
-import org.folio.dew.error.BursarNoMatchedAccountsException;
+import org.folio.dew.error.BursarNoAccountsToTransferException;
 import org.folio.dew.helpers.bursarfeesfines.BursarFeesFinesTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -240,7 +240,7 @@ class NoFeeFineMatchingCriteriaTest extends BaseBatchTest {
     JobExecution jobExecution = testLauncher.launchJob(jobParameters);
 
     assertThat(jobExecution.getExitStatus(), is(ExitStatus.FAILED));
-    assertThat(jobExecution.getAllFailureExceptions(), contains(instanceOf(BursarNoMatchedAccountsException.class)));
+    assertThat(jobExecution.getAllFailureExceptions(), contains(instanceOf(BursarNoAccountsToTransferException.class)));
 
     wireMockServer.verify(getRequestedFor(urlEqualTo(BursarFeesFinesTestUtils.ALL_OPEN_ACCOUNTS_GET_REQUEST)));
 

--- a/src/test/java/org/folio/dew/bursarfeesfines/NoFeesFinesTest.java
+++ b/src/test/java/org/folio/dew/bursarfeesfines/NoFeesFinesTest.java
@@ -7,11 +7,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import org.folio.dew.BaseBatchTest;
+import org.folio.dew.error.BursarNoAccountsToTransferException;
 import org.folio.dew.helpers.bursarfeesfines.BursarFeesFinesTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,11 +56,7 @@ class NoFeesFinesTest extends BaseBatchTest {
 
     // job status should be FAILED
     assertThat(jobExecution.getExitStatus(), is(ExitStatus.FAILED));
-    assertThat(jobExecution.getAllFailureExceptions()
-      .stream()
-      .map(Throwable::getMessage)
-      .filter(message -> message.contains("No accounts found"))
-      .toList(), hasSize(1));
+    assertThat(jobExecution.getAllFailureExceptions(), hasItem(instanceOf(BursarNoAccountsToTransferException.class)));
 
     // check that the ACCOUNT_GET_REQUEST endpoint was hit
     wireMockServer.verify(getRequestedFor(urlEqualTo(BursarFeesFinesTestUtils.ALL_OPEN_ACCOUNTS_GET_REQUEST)));


### PR DESCRIPTION
This uses custom exceptions for the bursar export where no accounts are found as some users were concerned seeing `IllegalStateException` in their logs:
<img width="391" height="298" alt="image" src="https://github.com/user-attachments/assets/36ea8d39-f806-4c14-874d-140d4b1f14fa" />

This is updated to `No fee/fine accounts were found with a remaining balance that matched the provided criteria.(BursarNoAccountsToTransferException)`.

There is also general cleanup of the `BursarTokenFormatter` class and increased logging during API operations in `BursarExportServiceImpl`.