### PR TITLE
[MODEXPW-624] Support dry runs for bursar exports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 ### Stories
 * [MODEXPW-576](https://folio-org.atlassian.net/browse/MODEXPW-576) Enhance "MARC authority headings update" Report with Record Type Column Based on Consortium Environment.
 * [MODEXPW-619](https://folio-org.atlassian.net/browse/MODEXPW-619) Remove the Linked bib fields column for the Authority headings change report
+* [MODEXPW-624](https://folio-org.atlassian.net/browse/MODEXPW-624) Support running bursar exports as a dry run (no transferring accounts).
 
 ### Bug fixes
 * [MODEXPW-617](https://folio-org.atlassian.net/browse/MODEXPW-617) Update Apache Kafka topic template to prevent ambiguous env name matches.

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/BursarExportJobConfig.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/BursarExportJobConfig.java
@@ -128,8 +128,6 @@ public class BursarExportJobConfig {
   @StepScope
   public BursarWriter writer(@Value("#{jobParameters['tempOutputFilePath']}") String tempOutputFilePath,
       @Value("#{jobExecutionContext['filename']}") String finalFilename, LocalFilesStorage localFilesStorage) {
-    log.error("BursarExportJobConfig.writer needs updating!!");
-
     String filename = tempOutputFilePath + '_' + finalFilename;
     WritableResource exportFileResource = new S3CompatibleResource<>(filename, localFilesStorage);
 

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/BursarExportStepListener.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/BursarExportStepListener.java
@@ -5,6 +5,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.folio.dew.batch.BaseStepListener;
 import org.folio.dew.batch.ExecutionContextUtils;
 import org.folio.dew.batch.bursarfeesfines.service.BursarExportUtils;
+import org.folio.dew.domain.dto.BursarExportJob;
 import org.folio.dew.domain.dto.JobParameterNames;
 import org.folio.dew.repository.LocalFilesStorage;
 import org.folio.dew.repository.RemoteFilesStorage;
@@ -34,6 +35,8 @@ public class BursarExportStepListener extends BaseStepListener {
     var remoteFilesStorage = super.getRemoteFilesStorage();
 
     var jobExecution = stepExecution.getJobExecution();
+    BursarExportJob jobConfig = jobExecution.getExecutionContext()
+      .get("jobConfig", BursarExportJob.class);
     String downloadFilename = jobExecution.getExecutionContext()
       .getString("filename");
     String filename = jobExecution.getJobParameters()
@@ -58,7 +61,7 @@ public class BursarExportStepListener extends BaseStepListener {
     ExecutionContextUtils.addToJobExecutionContext(stepExecution, JobParameterNames.BURSAR_FEES_FINES_FILE_NAME, key, ";");
 
     ExecutionContextUtils.addToJobExecutionContext(stepExecution, JobParameterNames.JOB_DESCRIPTION,
-        String.format(BursarExportUtils.getJobDescriptionPart(), stepExecution.getWriteCount()), "\n");
+        BursarExportUtils.getJobDescription(jobConfig, stepExecution.getWriteCount()), "\n");
 
     return exitStatus;
   }

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
@@ -44,6 +44,7 @@ public class TransferFeesFinesTasklet implements Tasklet {
       .get("filteredAccounts");
 
     if (CollectionUtils.isEmpty(filteredAccounts)) {
+      log.warn("No accounts to transfer for this export job; skipping transfer step.");
       return RepeatStatus.FINISHED;
     }
 

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
@@ -44,7 +44,6 @@ public class TransferFeesFinesTasklet implements Tasklet {
       .get("filteredAccounts");
 
     if (CollectionUtils.isEmpty(filteredAccounts)) {
-      log.warn("No accounts to transfer for this export job; skipping transfer step.");
       return RepeatStatus.FINISHED;
     }
 

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
@@ -2,9 +2,8 @@ package org.folio.dew.batch.bursarfeesfines;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
-import org.folio.dew.batch.ExecutionContextUtils;
 import org.folio.dew.batch.bursarfeesfines.service.BursarExportService;
 import org.folio.dew.domain.dto.BursarExportJob;
 import org.folio.dew.domain.dto.bursarfeesfines.AccountWithAncillaryData;
@@ -15,6 +14,7 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.stereotype.Component;
 
+@Log4j2
 @Component
 @StepScope
 @RequiredArgsConstructor
@@ -24,17 +24,30 @@ public class TransferFeesFinesTasklet implements Tasklet {
 
   @Override
   public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
-    // from AccountItemReader
+    BursarExportJob jobConfig = contribution
+      .getStepExecution()
+      .getJobExecution()
+      .getExecutionContext()
+      .get("jobConfig", BursarExportJob.class);
+
+    if (Boolean.TRUE.equals(jobConfig.getDryRun())) {
+      log.warn("Bursar export is configured as a dry run; no transfer will be performed.");
+      return RepeatStatus.FINISHED;
+    }
+
+    // supplied from AccountItemReader
     @SuppressWarnings("unchecked")
-    List<AccountWithAncillaryData> filteredAccounts = (List<AccountWithAncillaryData>) contribution.getStepExecution()
+    List<AccountWithAncillaryData> filteredAccounts = (List<AccountWithAncillaryData>) contribution
+      .getStepExecution()
       .getJobExecution()
       .getExecutionContext()
       .get("filteredAccounts");
 
-    if (CollectionUtils.isNotEmpty(filteredAccounts)) {
-      exportService.transferAccounts(filteredAccounts,
-          (BursarExportJob) ExecutionContextUtils.getExecutionVariable(contribution.getStepExecution(), "jobConfig"));
+    if (CollectionUtils.isEmpty(filteredAccounts)) {
+      return RepeatStatus.FINISHED;
     }
+
+    exportService.transferAccounts(filteredAccounts, jobConfig);
 
     return RepeatStatus.FINISHED;
   }

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
@@ -30,10 +30,6 @@ public class TransferFeesFinesTasklet implements Tasklet {
       .getExecutionContext()
       .get("jobConfig", BursarExportJob.class);
 
-    log.info("==========================================");
-    log.info("Got jobconfig with dryRun: {}; {}", jobConfig.getDryRun(), jobConfig);
-    log.info("==========================================");
-
     if (Boolean.TRUE.equals(jobConfig.getDryRun())) {
       log.warn("Bursar export is configured as a dry run; no transfer will be performed.");
       return RepeatStatus.FINISHED;

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTasklet.java
@@ -30,6 +30,10 @@ public class TransferFeesFinesTasklet implements Tasklet {
       .getExecutionContext()
       .get("jobConfig", BursarExportJob.class);
 
+    log.info("==========================================");
+    log.info("Got jobconfig with dryRun: {}; {}", jobConfig.getDryRun(), jobConfig);
+    log.info("==========================================");
+
     if (Boolean.TRUE.equals(jobConfig.getDryRun())) {
       log.warn("Bursar export is configured as a dry run; no transfer will be performed.");
       return RepeatStatus.FINISHED;

--- a/src/main/java/org/folio/dew/batch/bursarfeesfines/service/BursarExportUtils.java
+++ b/src/main/java/org/folio/dew/batch/bursarfeesfines/service/BursarExportUtils.java
@@ -2,6 +2,7 @@ package org.folio.dew.batch.bursarfeesfines.service;
 
 import java.time.Instant;
 import lombok.experimental.UtilityClass;
+import org.folio.dew.domain.dto.BursarExportJob;
 
 @UtilityClass
 public class BursarExportUtils {
@@ -11,13 +12,17 @@ public class BursarExportUtils {
 
   private static final String FILE_PATTERN = "lib_%s.dat";
   private static final String DESCRIPTION_PATTERN = "# of accounts: %d";
+  private static final String DRY_RUN_DESCRIPTION_PATTERN = "[TESTING MODE] # of accounts: %d";
 
   public static String getFilename() {
-    return String.format(FILE_PATTERN, Instant.now()
-      .toString());
+    return String.format(FILE_PATTERN, Instant.now().toString());
   }
 
-  public static String getJobDescriptionPart() {
-    return DESCRIPTION_PATTERN;
+  public static String getJobDescription(BursarExportJob jobConfig, long numWrites) {
+    if (Boolean.TRUE.equals(jobConfig.getDryRun())) {
+      return String.format(DRY_RUN_DESCRIPTION_PATTERN, numWrites);
+    } else {
+      return String.format(DESCRIPTION_PATTERN, numWrites);
+    }
   }
 }

--- a/src/test/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTaskletTest.java
+++ b/src/test/java/org/folio/dew/batch/bursarfeesfines/TransferFeesFinesTaskletTest.java
@@ -1,0 +1,96 @@
+package org.folio.dew.batch.bursarfeesfines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.folio.dew.batch.bursarfeesfines.service.BursarExportService;
+import org.folio.dew.domain.dto.BursarExportJob;
+import org.folio.dew.domain.dto.bursarfeesfines.AccountWithAncillaryData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+
+@ExtendWith(MockitoExtension.class)
+class TransferFeesFinesTaskletTest {
+
+  @Mock
+  BursarExportService bursarExportService;
+
+  @InjectMocks
+  TransferFeesFinesTasklet tasklet;
+
+  @Mock
+  StepContribution mockedStepContribution;
+
+  @Mock
+  StepExecution mockedStepExecution;
+
+  @Mock
+  JobExecution mockedJobExecution;
+
+  @Mock
+  ExecutionContext mockedExecutionContext;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(mockedStepContribution.getStepExecution()).thenReturn(mockedStepExecution);
+    lenient().when(mockedStepExecution.getJobExecution()).thenReturn(mockedJobExecution);
+    lenient().when(mockedJobExecution.getExecutionContext()).thenReturn(mockedExecutionContext);
+  }
+
+  @Test
+  void testDryRun() {
+    when(mockedExecutionContext.get("jobConfig", BursarExportJob.class)).thenReturn(jobConfigWithDryRun(true));
+
+    assertEquals(RepeatStatus.FINISHED, tasklet.execute(mockedStepContribution, null));
+
+    verifyNoInteractions(bursarExportService);
+  }
+
+  @Test
+  void testNoAccounts() {
+    when(mockedExecutionContext.get("jobConfig", BursarExportJob.class)).thenReturn(jobConfigWithDryRun(false));
+    when(mockedExecutionContext.get("filteredAccounts")).thenReturn(List.of());
+
+    assertEquals(RepeatStatus.FINISHED, tasklet.execute(mockedStepContribution, null));
+
+    verifyNoInteractions(bursarExportService);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(booleans = { false })
+  void testNormal(Boolean dryRun) {
+    List<AccountWithAncillaryData> accounts = List.of(
+      AccountWithAncillaryData.builder().build(),
+      AccountWithAncillaryData.builder().build()
+    );
+    BursarExportJob jobConfig = jobConfigWithDryRun(dryRun);
+    when(mockedExecutionContext.get("jobConfig", BursarExportJob.class)).thenReturn(jobConfig);
+    when(mockedExecutionContext.get("filteredAccounts")).thenReturn(accounts);
+
+    assertEquals(RepeatStatus.FINISHED, tasklet.execute(mockedStepContribution, null));
+
+    verify(bursarExportService, only()).transferAccounts(accounts, jobConfigWithDryRun(dryRun));
+  }
+
+  static BursarExportJob jobConfigWithDryRun(Boolean dryRun) {
+    return new BursarExportJob().dryRun(dryRun);
+  }
+}

--- a/src/test/java/org/folio/dew/batch/bursarfeesfines/service/BursarExportUtilsTest.java
+++ b/src/test/java/org/folio/dew/batch/bursarfeesfines/service/BursarExportUtilsTest.java
@@ -5,7 +5,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 
 import java.util.regex.Pattern;
+import org.folio.dew.domain.dto.BursarExportJob;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class BursarExportUtilsTest {
 
@@ -16,9 +20,17 @@ class BursarExportUtilsTest {
     assertThat(BursarExportUtils.getFilename(), matchesPattern(pattern));
   }
 
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(booleans = { false })
+  void testGetJobDescriptionWithoutDryRun(Boolean dryRun) {
+    String expected = "# of accounts: 123";
+    assertThat(BursarExportUtils.getJobDescription(new BursarExportJob().dryRun(dryRun), 123L), is(expected));
+  }
+
   @Test
-  void testGetJobDescriptionPart() {
-    String expected = "# of accounts: %d";
-    assertThat(BursarExportUtils.getJobDescriptionPart(), is(expected));
+  void testGetJobDescriptionWithDryRun() {
+    String expected = "[TESTING MODE] # of accounts: 123";
+    assertThat(BursarExportUtils.getJobDescription(new BursarExportJob().dryRun(true), 123L), is(expected));
   }
 }


### PR DESCRIPTION
 # [Jira MODEXPW-624](https://folio-org.atlassian.net/browse/MODEXPW-624)

## Purpose
Users would like to run bursar exports without the underlying accounts being transferred. This allows easier testing and verification of the export configurations before any data are actually changed.

## Approach
Adds support for a `dryRun` flag in the configuration schema which will skip the API calls to transfer accounts.
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes? No