### PR TITLE
MODEXPW-651: Always format email context createdAt with millisecond precision

### DIFF
--- a/src/main/java/org/folio/dew/batch/acquisitions/mapper/OrderEmailContextMapper.java
+++ b/src/main/java/org/folio/dew/batch/acquisitions/mapper/OrderEmailContextMapper.java
@@ -32,7 +32,8 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -44,6 +45,8 @@ import java.util.function.Predicate;
 @RequiredArgsConstructor
 @Log4j2
 public class OrderEmailContextMapper {
+
+  private static final DateTimeFormatter CREATED_AT_FORMATTER = new DateTimeFormatterBuilder().appendInstant(3).toFormatter();
 
   private final IdentifierTypeService identifierTypeService;
   private final ContributorNameTypeService contributorNameTypeService;
@@ -60,10 +63,14 @@ public class OrderEmailContextMapper {
           .toList()))
       .toList();
     return OrderEmailContext.builder()
-      .createdAt(Instant.now().truncatedTo(ChronoUnit.MILLIS).toString())
+      .createdAt(formatCreatedAt(Instant.now()))
       .organization(mapOrganization(orders))
       .orders(orderWrappers)
       .build();
+  }
+
+  static String formatCreatedAt(Instant instant) {
+    return CREATED_AT_FORMATTER.format(instant);
   }
 
   private OrganizationContext mapOrganization(List<CompositePurchaseOrder> orders) {

--- a/src/test/java/org/folio/dew/batch/acquisitions/mapper/OrderEmailContextMapperTest.java
+++ b/src/test/java/org/folio/dew/batch/acquisitions/mapper/OrderEmailContextMapperTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -174,6 +175,11 @@ class OrderEmailContextMapperTest {
     OrderEmailContext ctx = mapper.buildContext(List.of());
 
     assertThat(ctx.getCreatedAt()).matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z");
+  }
+
+  @Test
+  void formatCreatedAt_wholeSecond_keepsMilliseconds() {
+    assertThat(OrderEmailContextMapper.formatCreatedAt(Instant.parse("2026-08-12T10:15:30Z"))).isEqualTo("2026-08-12T10:15:30.000Z");
   }
 
   @Test


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEXPW-651

## Purpose
OrderEmailContextMapperTest.buildContext_setsCreatedAt:177 fails in about .1 % of all runs with this error:

```
Expecting actual:
  "2026-08-11T15:33:47Z"
to match pattern:
  "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"
```

Example: https://github.com/folio-org/mod-data-export-worker/actions/runs/31503434083/job/93819003252

Cause: Instant.toString() omits the fractional part when the nano-of-second is zero, so roughly one order email in a thousand carried a createdAt without milliseconds and OrderEmailContextMapperTest failed at the same rate.

## Approach

A fixed 3-digit millisecond instant formatter makes the output deterministic.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - n/a Were any API paths or methods changed, added or removed?
  - n/a Were there any schema changes?
  - n/a Did any of the interface versions change?
  - n/a Were permissions changed, added, or removed?
  - n/a Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.